### PR TITLE
Don't crash when compiling in release mode

### DIFF
--- a/src/build_loader.rs
+++ b/src/build_loader.rs
@@ -4,6 +4,7 @@ fn main() {
     gcc::Config::new()
         .flag("-static")
         .flag("-nostdlib")
+        .flag("-ffreestanding")
         .file("src/kernel/execve/loader/loader.c")
         .out_dir("src/kernel/execve/loader")
         .compile_binary("binary_loader_exe");


### PR DESCRIPTION
gcc and clang do NOT take '-nostdlib' to mean 'run without dynamic
libraries'; instead they take it to mean "don't use the standard
library, I'm going to use my own". To actually run without dynamic
libraries you need -ffreestanding.

see https://gcc.gnu.org/onlinedocs/gcc/Link-Options.html,
https://gcc.gnu.org/onlinedocs/gcc/Standards.html, and
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90701 for details.

addresses https://github.com/proot-me/proot-rs/issues/3