### PR TITLE
Handle binary for shebangs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ clap = "2.25.1"
 syscall = "0.2.1"
 lazy_static = "0.2.8"
 byteorder = "1.1.0"
+bstr = "0.1"
 
 [build-dependencies]
 gcc = { git = "https://github.com/vincenthage/gcc-rs", branch = "master" }

--- a/src/kernel/execve/shebang.rs
+++ b/src/kernel/execve/shebang.rs
@@ -1,8 +1,11 @@
-use std::path::{Path, PathBuf};
-use std::fs::File;
-use std::io::{BufRead, BufReader};
+extern crate bstr;
+
+use self::bstr::BString;
 use errors::{Error, Result};
 use filesystem::{FileSystem, Translator};
+use std::fs::File;
+use std::io::{BufReader, Read};
+use std::path::{Path, PathBuf};
 
 /// Expand in argv[] the shebang of `user_path`, if any.  This function
 /// returns -errno if an error occurred, 1 if a shebang was found and
@@ -134,20 +137,32 @@ pub fn translate_and_check_exec(fs: &FileSystem, guest_path: &Path) -> Result<Pa
 ///     string can include white space.
 //const char *host_path, char user_path[PATH_MAX], char argument[BINPRM_BUF_SIZE]
 fn extract(host_path: &Path) -> Result<Option<PathBuf>> {
-    let file = File::open(host_path)?;
-    let mut first_line = String::new();
-    BufReader::new(file).read_line(&mut first_line)?;
-    if !first_line.starts_with("#!") {
-        return Ok(None);
+    let mut bytes = BufReader::new(File::open(host_path)?).bytes();
+    match (bytes.next(), bytes.next()) {
+        (Some(Err(err)), _) | (_, Some(Err(err))) => return Err(Error::from(err)),
+        (Some(Ok(b'#')), Some(Ok(b'!'))) => {}
+        _ => return Ok(None),
     }
-
-    let mut arguments = first_line[2..]
-        .split(" ")
-        .map(|s| s.trim());
-    match arguments.next() {
-        None => Err(Error::InvalidPath("Cannot have empty shebang")),
-        Some(path) => Ok(Some(Path::new(path).to_path_buf()))
+    let first_line = bytes
+        .take_while(|c| match c {
+            Ok(b'\n') => true,
+            _ => false,
+        })
+        .collect::<std::result::Result<Vec<u8>, _>>()?;
+    let path: Vec<u8> = first_line
+        .clone()
+        .into_iter()
+        .take_while(|c| !c.is_ascii_whitespace())
+        .collect();
+    if path.is_empty() {
+        return Err(Error::InvalidPath("Cannot have empty shebang"));
     }
+    // NOTE: this unwrap may fail on non-UNIX systems (a.k.a Windows)
+    // where paths may not be arbitrary bytes
+    let arg = first_line[path.len()..].to_vec();
+    let mut argv = PathBuf::from(BString::from(path).to_path().unwrap());
+    argv.push(BString::from_vec(arg).to_path().unwrap());
+    Ok(Some(argv))
     //
     //	/* Skip leading spaces. */
     //	do {
@@ -258,13 +273,11 @@ fn extract(host_path: &Path) -> Result<Option<PathBuf>> {
     //	return 1;
 }
 
-
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
     use filesystem::FileSystem;
+    use std::path::PathBuf;
 
     #[test]
     fn test_extract_shebang_not_script() {


### PR DESCRIPTION
Addresses #8.

The code here is really not fun, but that's because dealing with binary strings in rust is really not fun.
Note that this introduces a dependency on BString so I didn't have to deal with turning a `Vec<u8>` into `OsString` which appears to be non-trivial.
Note that this will crash on windows for binary files, not sure if the project plans to run on windows.

The following tests now pass because of this pull:
- `test kernel::execve::shebang::tests::test_extract_shebang_not_script`
- `test kernel::execve::shebang::tests::test_expand_shebang_not_script`