### PR TITLE
Fix cargo test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "bstr"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59604ece62a407dc9164732e5adea02467898954c3a5811fd2dc140af14ef15b"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,6 +97,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba4aede83fc3617411dc6993bc8c70919750c1c257c6ca6a502aed6e0e2394ae"
 
 [[package]]
+name = "memchr"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+
+[[package]]
 name = "nix"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -101,6 +118,7 @@ dependencies = [
 name = "proot-rs"
 version = "0.1.0"
 dependencies = [
+ "bstr",
  "byteorder",
  "clap",
  "gcc",
@@ -108,6 +126,15 @@ dependencies = [
  "libc",
  "nix",
  "sc",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,9 +34,9 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "bstr"
-version = "0.1.4"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59604ece62a407dc9164732e5adea02467898954c3a5811fd2dc140af14ef15b"
+checksum = "a40b47ad93e1a5404e6c18dec46b628214fee441c70f4ab5d6942142cc268a3d"
 dependencies = [
  "lazy_static",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ clap = "2.25.1"
 sc = "0.2.3"
 lazy_static = "1.4.0"
 byteorder = "1.1.0"
-bstr = "0.1"
+bstr = "0.2.15"
 
 [build-dependencies]
 gcc = { git = "https://github.com/vincenthage/gcc-rs", branch = "master" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ clap = "2.25.1"
 sc = "0.2.3"
 lazy_static = "1.4.0"
 byteorder = "1.1.0"
+bstr = "0.1"
 
 [build-dependencies]
 gcc = { git = "https://github.com/vincenthage/gcc-rs", branch = "master" }

--- a/src/filesystem/canonicalization.rs
+++ b/src/filesystem/canonicalization.rs
@@ -108,12 +108,12 @@ mod tests {
     #[test]
     fn test_canonicalize_normal_path() {
         // "/etc" on the host, "/" on the guest
-        let mut fs = FileSystem::with_root("/etc");
+        let mut fs = FileSystem::with_root("/usr");
 
         assert_eq!(
-            fs.canonicalize(&PathBuf::from("/acpi/./../acpi//events"), false)
+            fs.canonicalize(&PathBuf::from("/bin/./../bin//sleep"), false)
                 .unwrap(),
-            PathBuf::from("/acpi/events")
+            PathBuf::from("/bin/sleep")
         );
 
         assert_eq!(
@@ -122,10 +122,10 @@ mod tests {
             PathBuf::from("/")
         );
 
-        fs.set_root("/etc/acpi");
+        fs.set_root("/etc");
         fs.add_binding(Binding::new("/usr/bin", "/bin", true));
 
-        // necessary, because nor "/bin" nor "/home" exist in "/etc/acpi"
+        // necessary, because nor "/bin" nor "/home" exist in "/etc"
         fs.set_glue_type(S_IRWXU | S_IRWXG | S_IRWXO);
 
         assert_eq!(

--- a/src/filesystem/initialization.rs
+++ b/src/filesystem/initialization.rs
@@ -71,13 +71,13 @@ mod tests {
     fn test_initialisation_cwd_absolute() {
         let mut fs = FileSystem::with_root("/");
 
-        fs.set_cwd(PathBuf::from("/etc/acpi"));
+        fs.set_cwd(PathBuf::from("/usr/bin"));
 
         assert_eq!(Ok(()), fs.initialize_cwd());
 
         assert!(fs.get_cwd().is_absolute());
         assert!(fs.get_cwd().exists());
-        assert_eq!(&PathBuf::from("/etc/acpi"), fs.get_cwd());
+        assert_eq!(&PathBuf::from("/usr/bin"), fs.get_cwd());
     }
 
     #[test]

--- a/src/filesystem/substitution.rs
+++ b/src/filesystem/substitution.rs
@@ -153,15 +153,15 @@ mod tests {
 
     #[test]
     fn test_substitute_intermediary_and_glue() {
-        let mut fs = FileSystem::with_root("/etc/acpi");
+        let mut fs = FileSystem::with_root("/usr/bin");
 
         // testing a folder
         let (path, file_type) = fs
-            .substitute_intermediary_and_glue(&Path::new("/events"))
+            .substitute_intermediary_and_glue(&Path::new("/sleep"))
             .expect("no error");
 
-        assert_eq!(path, PathBuf::from("/etc/acpi/events")); // "/" => "/etc/acpi/"
-        assert!(file_type.unwrap().is_dir());
+        assert_eq!(path, PathBuf::from("/usr/bin/sleep")); // "/" => "/usr/bin/"
+        assert!(file_type.unwrap().is_file());
 
         fs.add_binding(Binding::new("/bin", "/bin", true));
 

--- a/src/filesystem/translation.rs
+++ b/src/filesystem/translation.rs
@@ -144,26 +144,26 @@ mod tests {
         ); // simple canonicalization here
 
         // "/etc/host" in the host, "/etc/guest" in the guest
-        fs.add_binding(Binding::new("/etc/acpi", "/home/test", true));
+        fs.add_binding(Binding::new("/usr/bin", "/home/test", true));
 
         assert_eq!(
-            fs.translate_path(&Path::new("/home/test/events"), false),
-            Ok(PathBuf::from("/etc/acpi/events"))
-        ); // "/home/test" -> "/etc/acpi"
+            fs.translate_path(&Path::new("/home/test/sleep"), false),
+            Ok(PathBuf::from("/usr/bin/sleep"))
+        ); // "/home/test" -> "/usr/bin"
     }
 
     #[test]
     fn test_translate_path_with_root() {
-        let mut fs = FileSystem::with_root("/etc/acpi");
+        let mut fs = FileSystem::with_root("/usr/bin");
 
         assert_eq!(
-            fs.translate_path(&Path::new("/events"), false),
-            Ok(PathBuf::from("/etc/acpi/events"))
-        ); // "/home/test" -> "/etc/acpi"
+            fs.translate_path(&Path::new("/sleep"), false),
+            Ok(PathBuf::from("/usr/bin/sleep"))
+        ); // "/home/test" -> "/usr/bin"
 
         fs.add_binding(Binding::new("/usr/bin", "/bin", true));
 
-        // necessary, because "/bin/true" probably doesn't exist in "/etc/acpi"
+        // necessary, because "/bin/true" probably doesn't exist in "/usr/bin"
         fs.set_glue_type(S_IRWXU | S_IRWXG | S_IRWXO);
 
         assert_eq!(
@@ -173,7 +173,7 @@ mod tests {
 
         assert_eq!(
             fs.translate_path(&Path::new("/bin/../home"), false),
-            Ok(PathBuf::from("/etc/acpi/home"))
+            Ok(PathBuf::from("/usr/bin/home"))
         ); // checking that the substitution only happens at the end ("/" is translated, not "/bin")
     }
 

--- a/src/kernel/execve/elf.rs
+++ b/src/kernel/execve/elf.rs
@@ -224,7 +224,7 @@ mod tests {
 
     #[test]
     fn test_get_elf_header_class_not_executable() {
-        let mut file = File::open(PathBuf::from("/etc/init/acpid.conf")).unwrap();
+        let mut file = File::open(PathBuf::from("/etc/hostname")).unwrap();
         assert_eq!(
             ElfHeader::extract_class(&mut file).unwrap_err(),
             Error::cant_exec("when extracting elf header from non executable file")

--- a/src/kernel/execve/load_info.rs
+++ b/src/kernel/execve/load_info.rs
@@ -288,12 +288,13 @@ mod tests {
     #[test]
     fn test_load_info_from_path_not_executable() {
         let fs = FileSystem::with_root("/");
-        let result = LoadInfo::from(&fs, &PathBuf::from("/etc/init/acpid.conf"));
+        let result = LoadInfo::from(&fs, &PathBuf::from("/etc/hostname"));
 
-        assert!(result.is_err());
         assert_eq!(
-            Error::cant_exec("when extracting elf header from non executable file"),
-            result.unwrap_err()
+            Err(Error::cant_exec(
+                "when extracting elf header from non executable file"
+            )),
+            result
         );
     }
 

--- a/src/register/regs.rs
+++ b/src/register/regs.rs
@@ -8,7 +8,7 @@ use std::fmt;
 use std::mem;
 use std::ptr::null_mut;
 
-const VOID: Word = 0;
+const VOID: Word = Word::MAX;
 
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum RegVersion {
@@ -324,7 +324,7 @@ impl fmt::Display for Registers {
 mod tests {
     use super::*;
     use nix::unistd::{execvp, Pid};
-    use sc::nr::NANOSLEEP;
+    use sc::nr::{CLOCK_NANOSLEEP, NANOSLEEP};
     use std::ffi::CString;
     use utils::tests::fork_test;
 
@@ -409,7 +409,8 @@ mod tests {
             0,
             // parent
             |tracee, _| {
-                if tracee.regs.get_sys_num(Current) == NANOSLEEP {
+                let sys_num = tracee.regs.get_sys_num(Current);
+                if sys_num == NANOSLEEP || sys_num == CLOCK_NANOSLEEP {
                     // NANOSLEEP enter stage
                     tracee.regs.set_restore_original_regs(false);
                     tracee.regs.save_current_regs(Original);


### PR DESCRIPTION
Make `cargo test` pass.

- [x] fix kernel::execve::shebang::tests::test_expand_shebang_not_script
- [x] fix `cargo test` timeout.
- [x] failure caused by some not existed file 