### PR TITLE
Rewrite eventloop code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 PRoot-rust.iml
 *.rs.bk
 /src/kernel/execve/loader/binary_loader_exe
+.vscode/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,12 +22,6 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
-
-[[package]]
-name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
@@ -50,10 +44,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
-name = "cfg-if"
-version = "0.1.10"
+name = "cc"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
@@ -63,7 +63,7 @@ checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
  "ansi_term",
  "atty",
- "bitflags 1.2.1",
+ "bitflags",
  "strsim",
  "textwrap",
  "unicode-width",
@@ -104,14 +104,14 @@ checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "nix"
-version = "0.9.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2c5afeb0198ec7be8569d666644b574345aad2e95a53baf3a532da3e0f3fb32"
+checksum = "fa9b4819da1bc61c0ea48b63b7bc8604064dd43013e7cc325df098d49cd7c18a"
 dependencies = [
- "bitflags 0.9.1",
+ "bitflags",
+ "cc",
  "cfg-if",
  "libc",
- "void",
 ]
 
 [[package]]
@@ -169,12 +169,6 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "proot-rs"
 version = "0.1.0"
 authors = ["vincenthage"]
 build = "src/build_loader.rs"
+edition = "2018"
 
 [dependencies]
 libc = "0.2.25"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 libc = "0.2.25"
-nix = "0.9.0"
+nix = "0.20.0"
 clap = "2.25.1"
 sc = "0.2.3"
 lazy_static = "1.4.0"

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly
+nightly-2021-03-24

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,7 @@
+use crate::filesystem::binding::Binding;
+use crate::filesystem::validation::{binding_validator, path_validator};
+use crate::filesystem::FileSystem;
 use clap::{App, Arg};
-use filesystem::binding::Binding;
-use filesystem::validation::{binding_validator, path_validator};
-use filesystem::FileSystem;
 use std::path::PathBuf;
 
 pub const DEFAULT_ROOTFS: &'static str = "/";

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,4 +1,4 @@
-use nix::errno;
+use nix::errno::Errno;
 use nix::Error as NixError;
 use std::io::{Error as IOError, ErrorKind as IOErrorKind};
 use std::{error, fmt, result, string};
@@ -7,7 +7,7 @@ pub type Result<T> = result::Result<T, Error>;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Error {
-    Sys(errno::Errno, &'static str),
+    Sys(Errno, &'static str),
     InvalidPath(&'static str),
     InvalidUtf8,
     IOError(IOErrorKind),
@@ -22,50 +22,50 @@ impl Error {
         }
     }
 
-    pub fn from_errno(errno: errno::Errno, message: &'static str) -> Error {
+    pub fn from_errno(errno: Errno, message: &'static str) -> Error {
         Error::Sys(errno, message)
     }
 
     pub fn invalid_argument(message: &'static str) -> Error {
-        Error::Sys(errno::EINVAL, message)
+        Error::Sys(Errno::EINVAL, message)
     }
 
     pub fn name_too_long(message: &'static str) -> Error {
-        Error::Sys(errno::ENAMETOOLONG, message)
+        Error::Sys(Errno::ENAMETOOLONG, message)
     }
 
     pub fn no_such_file_or_dir(message: &'static str) -> Error {
-        Error::Sys(errno::ENOENT, message)
+        Error::Sys(Errno::ENOENT, message)
     }
 
     #[cfg(test)]
     pub fn is_a_directory(message: &'static str) -> Error {
-        Error::Sys(errno::EISDIR, message)
+        Error::Sys(Errno::EISDIR, message)
     }
 
     pub fn not_a_directory(message: &'static str) -> Error {
-        Error::Sys(errno::ENOTDIR, message)
+        Error::Sys(Errno::ENOTDIR, message)
     }
 
     pub fn too_many_symlinks(message: &'static str) -> Error {
-        Error::Sys(errno::ELOOP, message)
+        Error::Sys(Errno::ELOOP, message)
     }
 
     pub fn cant_exec(message: &'static str) -> Error {
-        Error::Sys(errno::ENOEXEC, message)
+        Error::Sys(Errno::ENOEXEC, message)
     }
 
     pub fn not_supported(message: &'static str) -> Error {
-        Error::Sys(errno::EOPNOTSUPP, message)
+        Error::Sys(Errno::EOPNOTSUPP, message)
     }
 
     pub fn bad_address(message: &'static str) -> Error {
-        Error::Sys(errno::EFAULT, message)
+        Error::Sys(Errno::EFAULT, message)
     }
 }
 
-impl From<errno::Errno> for Error {
-    fn from(errno: errno::Errno) -> Error {
+impl From<Errno> for Error {
+    fn from(errno: Errno) -> Error {
         Error::from_errno(errno, "from sys errno")
     }
 }
@@ -80,7 +80,7 @@ impl From<IOError> for Error {
     fn from(io_error: IOError) -> Error {
         match io_error.raw_os_error() {
             // we try to convert it to an errno
-            Some(errno) => Error::Sys(errno::Errno::from_i32(errno), "from IO error"),
+            Some(errno) => Error::Sys(Errno::from_i32(errno), "from IO error"),
             // if not successful, we keep the IOError to retain the context of the error
             None => Error::IOError(io_error.kind()),
         }

--- a/src/filesystem/binding.rs
+++ b/src/filesystem/binding.rs
@@ -1,4 +1,4 @@
-use errors::{Error, Result};
+use crate::errors::{Error, Result};
 use libc::PATH_MAX;
 use nix::NixPath;
 use std::path::{Path, PathBuf};

--- a/src/filesystem/canonicalization.rs
+++ b/src/filesystem/canonicalization.rs
@@ -88,7 +88,7 @@ mod tests {
     use super::*;
     use crate::filesystem::binding::Binding;
     use crate::filesystem::FileSystem;
-    use nix::sys::stat::{S_IRWXG, S_IRWXO, S_IRWXU};
+    use nix::sys::stat::Mode;
     use std::path::PathBuf;
 
     #[test]
@@ -126,7 +126,7 @@ mod tests {
         fs.add_binding(Binding::new("/usr/bin", "/bin", true));
 
         // necessary, because nor "/bin" nor "/home" exist in "/etc"
-        fs.set_glue_type(S_IRWXU | S_IRWXG | S_IRWXO);
+        fs.set_glue_type(Mode::S_IRWXU | Mode::S_IRWXG | Mode::S_IRWXO);
 
         assert_eq!(
             fs.canonicalize(&PathBuf::from("/bin/../home"), false)
@@ -146,7 +146,7 @@ mod tests {
         );
 
         // necessary, because nor "/test" probably doesn't exist
-        fs.set_glue_type(S_IRWXU | S_IRWXG | S_IRWXO);
+        fs.set_glue_type(Mode::S_IRWXU | Mode::S_IRWXG | Mode::S_IRWXO);
 
         assert_eq!(
             fs.canonicalize(&PathBuf::from("/bin/../test"), false)

--- a/src/filesystem/canonicalization.rs
+++ b/src/filesystem/canonicalization.rs
@@ -1,6 +1,6 @@
-use errors::{Error, Result};
-use filesystem::substitution::Substitutor;
-use filesystem::FileSystem;
+use crate::errors::{Error, Result};
+use crate::filesystem::substitution::Substitutor;
+use crate::filesystem::FileSystem;
 use std::path::{Component, Path, PathBuf};
 
 pub trait Canonicalizer {
@@ -86,8 +86,8 @@ impl Canonicalizer for FileSystem {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use filesystem::binding::Binding;
-    use filesystem::FileSystem;
+    use crate::filesystem::binding::Binding;
+    use crate::filesystem::FileSystem;
     use nix::sys::stat::{S_IRWXG, S_IRWXO, S_IRWXU};
     use std::path::PathBuf;
 

--- a/src/filesystem/fs.rs
+++ b/src/filesystem/fs.rs
@@ -1,6 +1,6 @@
-use errors::Result;
-use filesystem::binding::Side::Host;
-use filesystem::binding::{Binding, Side};
+use crate::errors::Result;
+use crate::filesystem::binding::Side::Host;
+use crate::filesystem::binding::{Binding, Side};
 use nix::sys::stat::Mode;
 use std::fs::Metadata;
 use std::path::{Path, PathBuf};
@@ -157,8 +157,8 @@ impl FileSystem {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use filesystem::binding::Binding;
-    use filesystem::binding::Side::{Guest, Host};
+    use crate::filesystem::binding::Binding;
+    use crate::filesystem::binding::Side::{Guest, Host};
     use std::path::{Path, PathBuf};
 
     #[test]

--- a/src/filesystem/initialization.rs
+++ b/src/filesystem/initialization.rs
@@ -1,5 +1,5 @@
-use errors::Result;
-use filesystem::{Canonicalizer, FileSystem};
+use crate::errors::Result;
+use crate::filesystem::{Canonicalizer, FileSystem};
 use nix::unistd::getcwd;
 use std::path::PathBuf;
 
@@ -50,7 +50,7 @@ impl Initialiser for FileSystem {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use filesystem::FileSystem;
+    use crate::filesystem::FileSystem;
     use std::path::PathBuf;
 
     #[test]

--- a/src/filesystem/substitution.rs
+++ b/src/filesystem/substitution.rs
@@ -1,7 +1,7 @@
-use errors::{Error, Result};
-use filesystem::binding::Direction;
-use filesystem::binding::Side::{Guest, Host};
-use filesystem::FileSystem;
+use crate::errors::{Error, Result};
+use crate::filesystem::binding::Direction;
+use crate::filesystem::binding::Side::{Guest, Host};
+use crate::filesystem::FileSystem;
 use nix::sys::stat::Mode;
 use std::fs::FileType;
 use std::path::{Path, PathBuf};
@@ -79,10 +79,10 @@ impl Substitutor for FileSystem {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use errors::Error;
-    use filesystem::binding::Binding;
-    use filesystem::binding::Side::{Guest, Host};
-    use filesystem::FileSystem;
+    use crate::errors::Error;
+    use crate::filesystem::binding::Binding;
+    use crate::filesystem::binding::Side::{Guest, Host};
+    use crate::filesystem::FileSystem;
     use std::path::{Path, PathBuf};
 
     #[test]

--- a/src/filesystem/temp.rs
+++ b/src/filesystem/temp.rs
@@ -1,4 +1,4 @@
-use errors::Result;
+use crate::errors::Result;
 use nix::unistd::getpid;
 use std::env;
 use std::fs;

--- a/src/filesystem/translation.rs
+++ b/src/filesystem/translation.rs
@@ -131,7 +131,7 @@ mod tests {
     use super::*;
     use crate::filesystem::binding::Binding;
     use crate::filesystem::FileSystem;
-    use nix::sys::stat::{S_IRWXG, S_IRWXO, S_IRWXU};
+    use nix::sys::stat::Mode;
     use std::path::{Path, PathBuf};
 
     #[test]
@@ -164,7 +164,7 @@ mod tests {
         fs.add_binding(Binding::new("/usr/bin", "/bin", true));
 
         // necessary, because "/bin/true" probably doesn't exist in "/usr/bin"
-        fs.set_glue_type(S_IRWXU | S_IRWXG | S_IRWXO);
+        fs.set_glue_type(Mode::S_IRWXU | Mode::S_IRWXG | Mode::S_IRWXO);
 
         assert_eq!(
             fs.translate_path(&Path::new("/bin/true"), false),

--- a/src/filesystem/translation.rs
+++ b/src/filesystem/translation.rs
@@ -1,9 +1,9 @@
-use errors::Result;
-use filesystem::binding::Direction;
-use filesystem::binding::Side::{Guest, Host};
-use filesystem::canonicalization::Canonicalizer;
-use filesystem::substitution::Substitutor;
-use filesystem::FileSystem;
+use crate::errors::Result;
+use crate::filesystem::binding::Direction;
+use crate::filesystem::binding::Side::{Guest, Host};
+use crate::filesystem::canonicalization::Canonicalizer;
+use crate::filesystem::substitution::Substitutor;
+use crate::filesystem::FileSystem;
 use std::path::{Path, PathBuf};
 
 pub trait Translator {
@@ -129,8 +129,8 @@ impl Translator for FileSystem {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use filesystem::binding::Binding;
-    use filesystem::FileSystem;
+    use crate::filesystem::binding::Binding;
+    use crate::filesystem::FileSystem;
     use nix::sys::stat::{S_IRWXG, S_IRWXO, S_IRWXU};
     use std::path::{Path, PathBuf};
 

--- a/src/kernel/enter.rs
+++ b/src/kernel/enter.rs
@@ -1,14 +1,14 @@
-use errors::Result;
-use kernel::execve;
-use kernel::groups::syscall_group_from_sysnum;
-use kernel::groups::SyscallGroup::*;
-use kernel::heap::*;
-use kernel::ptrace::*;
-use kernel::socket::*;
-use kernel::standard::*;
-use process::proot::InfoBag;
-use process::tracee::Tracee;
-use register::Current;
+use crate::errors::Result;
+use crate::kernel::execve;
+use crate::kernel::groups::syscall_group_from_sysnum;
+use crate::kernel::groups::SyscallGroup::*;
+use crate::kernel::heap::*;
+use crate::kernel::ptrace::*;
+use crate::kernel::socket::*;
+use crate::kernel::standard::*;
+use crate::process::proot::InfoBag;
+use crate::process::tracee::Tracee;
+use crate::register::Current;
 
 pub fn translate(info_bag: &InfoBag, tracee: &mut Tracee) -> Result<()> {
     let sys_type = syscall_group_from_sysnum(tracee.regs.get_sys_num(Current));

--- a/src/kernel/execve/elf.rs
+++ b/src/kernel/execve/elf.rs
@@ -1,5 +1,5 @@
-use errors::{Error, Result};
-use filesystem::readers::ExtraReader;
+use crate::errors::{Error, Result};
+use crate::filesystem::readers::ExtraReader;
 use std::fs::File;
 use std::io::{Read, Seek, SeekFrom};
 use std::mem;
@@ -219,7 +219,7 @@ impl ElfHeader {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use errors::Error;
+    use crate::errors::Error;
     use std::path::PathBuf;
 
     #[test]

--- a/src/kernel/execve/enter.rs
+++ b/src/kernel/execve/enter.rs
@@ -1,11 +1,11 @@
-use errors::{Error, Result};
-use filesystem::Translator;
-use kernel::execve::load_info::LoadInfo;
-use kernel::execve::loader::LoaderFile;
-use kernel::execve::shebang;
+use crate::errors::{Error, Result};
+use crate::filesystem::Translator;
+use crate::kernel::execve::load_info::LoadInfo;
+use crate::kernel::execve::loader::LoaderFile;
+use crate::kernel::execve::shebang;
+use crate::process::tracee::Tracee;
+use crate::register::{PtraceReader, SysArg1};
 use nix::errno::Errno;
-use process::tracee::Tracee;
-use register::{PtraceReader, SysArg1};
 
 pub fn translate(tracee: &mut Tracee, loader: &dyn LoaderFile) -> Result<()> {
     //TODO: implement this part for ptrace translation
@@ -97,11 +97,11 @@ pub fn translate(tracee: &mut Tracee, loader: &dyn LoaderFile) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::register::{Current, PtraceReader};
+    use crate::utils::tests::fork_test;
     use nix::unistd::execvp;
-    use register::{Current, PtraceReader};
     use sc::nr::{EXECVE, NANOSLEEP};
     use std::ffi::CString;
-    use utils::tests::fork_test;
 
     #[test]
     fn test_execve_translate_enter() {

--- a/src/kernel/execve/exit.rs
+++ b/src/kernel/execve/exit.rs
@@ -1,7 +1,7 @@
-use errors::Result;
-use kernel::exit::SyscallExitResult;
-use process::tracee::Tracee;
-use register::{Current, SysResult};
+use crate::errors::Result;
+use crate::kernel::exit::SyscallExitResult;
+use crate::process::tracee::Tracee;
+use crate::register::{Current, SysResult};
 
 pub fn translate(tracee: &mut Tracee) -> SyscallExitResult {
     let syscall_result = tracee.regs.get(Current, SysResult) as isize;

--- a/src/kernel/execve/load_info.rs
+++ b/src/kernel/execve/load_info.rs
@@ -5,8 +5,8 @@ use crate::kernel::execve::elf::{ElfHeader, ExecutableClass, ProgramHeader};
 use crate::kernel::execve::elf::{PF_R, PF_W, PF_X, PT_INTERP, PT_LOAD};
 use crate::kernel::execve::shebang::translate_and_check_exec;
 use crate::register::Word;
-use nix::sys::mman::{MapFlags, MAP_ANONYMOUS, MAP_FIXED, MAP_PRIVATE};
-use nix::sys::mman::{ProtFlags, PROT_EXEC, PROT_NONE, PROT_READ, PROT_WRITE};
+use nix::sys::mman::MapFlags;
+use nix::sys::mman::ProtFlags;
 use nix::unistd::{sysconf, SysconfVar};
 use std::fs::File;
 use std::io::{Seek, SeekFrom};
@@ -121,7 +121,7 @@ impl LoadInfo {
             offset: offset & *PAGE_MASK,
             addr: start_address,
             length: end_address - start_address,
-            flags: MAP_PRIVATE | MAP_FIXED,
+            flags: MapFlags::MAP_PRIVATE | MapFlags::MAP_FIXED,
             prot: prot,
             clear_length: 0,
         };
@@ -147,7 +147,7 @@ impl LoadInfo {
                     addr: start_address,
                     length: end_address - start_address,
                     clear_length: 0,
-                    flags: MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED,
+                    flags: MapFlags::MAP_PRIVATE | MapFlags::MAP_ANONYMOUS | MapFlags::MAP_FIXED,
                     prot: prot,
                 };
 
@@ -261,9 +261,9 @@ fn process_flag<T>(flags: u32, compare_flag: u32, success_flag: T, default_flag:
 
 #[inline]
 fn process_prot_flags(flags: u32) -> ProtFlags {
-    let read_flag = process_flag(flags, PF_R, PROT_READ, PROT_NONE);
-    let write_flag = process_flag(flags, PF_W, PROT_WRITE, PROT_NONE);
-    let execute_flag = process_flag(flags, PF_X, PROT_EXEC, PROT_NONE);
+    let read_flag = process_flag(flags, PF_R, ProtFlags::PROT_READ, ProtFlags::PROT_NONE);
+    let write_flag = process_flag(flags, PF_W, ProtFlags::PROT_WRITE, ProtFlags::PROT_NONE);
+    let execute_flag = process_flag(flags, PF_X, ProtFlags::PROT_EXEC, ProtFlags::PROT_NONE);
 
     read_flag | write_flag | execute_flag
 }

--- a/src/kernel/execve/load_info.rs
+++ b/src/kernel/execve/load_info.rs
@@ -1,13 +1,13 @@
-use errors::{Error, Result};
-use filesystem::readers::ExtraReader;
-use filesystem::FileSystem;
-use kernel::execve::elf::{ElfHeader, ExecutableClass, ProgramHeader};
-use kernel::execve::elf::{PF_R, PF_W, PF_X, PT_INTERP, PT_LOAD};
-use kernel::execve::shebang::translate_and_check_exec;
+use crate::errors::{Error, Result};
+use crate::filesystem::readers::ExtraReader;
+use crate::filesystem::FileSystem;
+use crate::kernel::execve::elf::{ElfHeader, ExecutableClass, ProgramHeader};
+use crate::kernel::execve::elf::{PF_R, PF_W, PF_X, PT_INTERP, PT_LOAD};
+use crate::kernel::execve::shebang::translate_and_check_exec;
+use crate::register::Word;
 use nix::sys::mman::{MapFlags, MAP_ANONYMOUS, MAP_FIXED, MAP_PRIVATE};
 use nix::sys::mman::{ProtFlags, PROT_EXEC, PROT_NONE, PROT_READ, PROT_WRITE};
 use nix::unistd::{sysconf, SysconfVar};
-use register::Word;
 use std::fs::File;
 use std::io::{Seek, SeekFrom};
 use std::path::{Path, PathBuf};
@@ -271,9 +271,9 @@ fn process_prot_flags(flags: u32) -> ProtFlags {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use errors::Error;
-    use filesystem::FileSystem;
-    use register::Word;
+    use crate::errors::Error;
+    use crate::filesystem::FileSystem;
+    use crate::register::Word;
     use std::path::PathBuf;
 
     #[test]

--- a/src/kernel/execve/loader.rs
+++ b/src/kernel/execve/loader.rs
@@ -1,5 +1,5 @@
-use errors::Result;
-use filesystem::temp::TempFile;
+use crate::errors::Result;
+use crate::filesystem::temp::TempFile;
 use libc::{S_IRUSR, S_IXUSR};
 use std::io::Write;
 use std::os::unix::fs::PermissionsExt;

--- a/src/kernel/execve/mod.rs
+++ b/src/kernel/execve/mod.rs
@@ -7,10 +7,10 @@ mod load_info;
 mod loader;
 mod shebang;
 
-use errors::Result;
-use kernel::execve::loader::LoaderFile;
-use kernel::exit::SyscallExitResult;
-use process::tracee::Tracee;
+use crate::errors::Result;
+use crate::kernel::execve::loader::LoaderFile;
+use crate::kernel::exit::SyscallExitResult;
+use crate::process::tracee::Tracee;
 
 pub fn enter(tracee: &mut Tracee, loader: &dyn LoaderFile) -> Result<()> {
     enter::translate(tracee, loader)

--- a/src/kernel/execve/shebang.rs
+++ b/src/kernel/execve/shebang.rs
@@ -3,8 +3,8 @@ extern crate bstr;
 use self::bstr::BStr;
 use self::bstr::BString;
 use self::bstr::ByteSlice;
-use errors::{Error, Result};
-use filesystem::{FileSystem, Translator};
+use crate::errors::{Error, Result};
+use crate::filesystem::{FileSystem, Translator};
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::{fs::File, io::Read};
@@ -281,7 +281,7 @@ fn extract(host_path: &Path) -> Result<Option<PathBuf>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use filesystem::FileSystem;
+    use crate::filesystem::FileSystem;
     use std::path::PathBuf;
 
     #[test]

--- a/src/kernel/exit.rs
+++ b/src/kernel/exit.rs
@@ -1,12 +1,12 @@
-use errors::Error;
-use kernel::execve;
-use kernel::groups::{syscall_group_from_sysnum, SyscallGroup};
-use kernel::heap::*;
-use kernel::ptrace::*;
-use kernel::socket::*;
-use kernel::standard::*;
-use process::tracee::Tracee;
-use register::{Current, SysResult, Word};
+use crate::errors::Error;
+use crate::kernel::execve;
+use crate::kernel::groups::{syscall_group_from_sysnum, SyscallGroup};
+use crate::kernel::heap::*;
+use crate::kernel::ptrace::*;
+use crate::kernel::socket::*;
+use crate::kernel::standard::*;
+use crate::process::tracee::Tracee;
+use crate::register::{Current, SysResult, Word};
 
 #[allow(dead_code)]
 pub enum SyscallExitResult {

--- a/src/kernel/heap/brk.rs
+++ b/src/kernel/heap/brk.rs
@@ -1,5 +1,5 @@
-use errors::Result;
-use kernel::exit::SyscallExitResult;
+use crate::errors::Result;
+use crate::kernel::exit::SyscallExitResult;
 
 pub fn enter() -> Result<()> {
     Ok(())

--- a/src/kernel/ptrace/ptrace.rs
+++ b/src/kernel/ptrace/ptrace.rs
@@ -1,5 +1,5 @@
-use errors::Result;
-use kernel::exit::SyscallExitResult;
+use crate::errors::Result;
+use crate::kernel::exit::SyscallExitResult;
 
 pub fn enter() -> Result<()> {
     Ok(())

--- a/src/kernel/ptrace/wait.rs
+++ b/src/kernel/ptrace/wait.rs
@@ -1,5 +1,5 @@
-use errors::Result;
-use kernel::exit::SyscallExitResult;
+use crate::errors::Result;
+use crate::kernel::exit::SyscallExitResult;
 
 pub fn enter() -> Result<()> {
     Ok(())

--- a/src/kernel/socket/accept.rs
+++ b/src/kernel/socket/accept.rs
@@ -1,6 +1,6 @@
-use errors::Result;
-use kernel::exit::SyscallExitResult;
-use kernel::socket::get_sockorpeer_name;
+use crate::errors::Result;
+use crate::kernel::exit::SyscallExitResult;
+use crate::kernel::socket::get_sockorpeer_name;
 
 pub fn enter() -> Result<()> {
     get_sockorpeer_name::enter()

--- a/src/kernel/socket/bind_connect.rs
+++ b/src/kernel/socket/bind_connect.rs
@@ -1,4 +1,4 @@
-use errors::Result;
+use crate::errors::Result;
 
 pub fn enter() -> Result<()> {
     Ok(())

--- a/src/kernel/socket/get_sockorpeer_name.rs
+++ b/src/kernel/socket/get_sockorpeer_name.rs
@@ -1,5 +1,5 @@
-use errors::Result;
-use kernel::exit::SyscallExitResult;
+use crate::errors::Result;
+use crate::kernel::exit::SyscallExitResult;
 
 pub fn enter() -> Result<()> {
     Ok(())

--- a/src/kernel/socket/socketcall.rs
+++ b/src/kernel/socket/socketcall.rs
@@ -1,5 +1,5 @@
-use errors::Result;
-use kernel::exit::SyscallExitResult;
+use crate::errors::Result;
+use crate::kernel::exit::SyscallExitResult;
 
 pub fn enter() -> Result<()> {
     Ok(())

--- a/src/kernel/standard/chdir.rs
+++ b/src/kernel/standard/chdir.rs
@@ -1,5 +1,5 @@
-use errors::Result;
-use kernel::exit::SyscallExitResult;
+use crate::errors::Result;
+use crate::kernel::exit::SyscallExitResult;
 
 pub fn enter() -> Result<()> {
     Ok(())

--- a/src/kernel/standard/chmod_access_mknod_at.rs
+++ b/src/kernel/standard/chmod_access_mknod_at.rs
@@ -1,4 +1,4 @@
-use errors::Result;
+use crate::errors::Result;
 
 pub fn enter() -> Result<()> {
     Ok(())

--- a/src/kernel/standard/dir_link_attr.rs
+++ b/src/kernel/standard/dir_link_attr.rs
@@ -1,4 +1,4 @@
-use errors::Result;
+use crate::errors::Result;
 
 pub fn enter() -> Result<()> {
     Ok(())

--- a/src/kernel/standard/getcwd.rs
+++ b/src/kernel/standard/getcwd.rs
@@ -1,5 +1,5 @@
-use errors::Result;
-use kernel::exit::SyscallExitResult;
+use crate::errors::Result;
+use crate::kernel::exit::SyscallExitResult;
 
 pub fn enter() -> Result<()> {
     Ok(())

--- a/src/kernel/standard/inotify_add_watch.rs
+++ b/src/kernel/standard/inotify_add_watch.rs
@@ -1,4 +1,4 @@
-use errors::Result;
+use crate::errors::Result;
 
 pub fn enter() -> Result<()> {
     Ok(())

--- a/src/kernel/standard/link_at.rs
+++ b/src/kernel/standard/link_at.rs
@@ -1,4 +1,4 @@
-use errors::Result;
+use crate::errors::Result;
 
 pub fn enter() -> Result<()> {
     Ok(())

--- a/src/kernel/standard/link_rename.rs
+++ b/src/kernel/standard/link_rename.rs
@@ -1,5 +1,5 @@
-use errors::Result;
-use kernel::exit::SyscallExitResult;
+use crate::errors::Result;
+use crate::kernel::exit::SyscallExitResult;
 
 /// Translates link and rename kernel
 pub fn enter() -> Result<()> {

--- a/src/kernel/standard/mount.rs
+++ b/src/kernel/standard/mount.rs
@@ -1,4 +1,4 @@
-use errors::Result;
+use crate::errors::Result;
 
 pub fn enter() -> Result<()> {
     Ok(())

--- a/src/kernel/standard/open.rs
+++ b/src/kernel/standard/open.rs
@@ -1,4 +1,4 @@
-use errors::Result;
+use crate::errors::Result;
 
 pub fn enter() -> Result<()> {
     Ok(())

--- a/src/kernel/standard/open_at.rs
+++ b/src/kernel/standard/open_at.rs
@@ -1,4 +1,4 @@
-use errors::Result;
+use crate::errors::Result;
 
 pub fn enter() -> Result<()> {
     Ok(())

--- a/src/kernel/standard/pivot_root.rs
+++ b/src/kernel/standard/pivot_root.rs
@@ -1,4 +1,4 @@
-use errors::Result;
+use crate::errors::Result;
 
 pub fn enter() -> Result<()> {
     Ok(())

--- a/src/kernel/standard/readlink_at.rs
+++ b/src/kernel/standard/readlink_at.rs
@@ -1,6 +1,6 @@
-use errors::Result;
-use kernel::exit::SyscallExitResult;
-use kernel::standard::unlink_mkdir_at;
+use crate::errors::Result;
+use crate::kernel::exit::SyscallExitResult;
+use crate::kernel::standard::unlink_mkdir_at;
 
 pub fn enter() -> Result<()> {
     unlink_mkdir_at::enter()

--- a/src/kernel/standard/rename_at.rs
+++ b/src/kernel/standard/rename_at.rs
@@ -1,6 +1,6 @@
-use errors::Result;
-use kernel::exit::SyscallExitResult;
-use kernel::standard::link_rename;
+use crate::errors::Result;
+use crate::kernel::exit::SyscallExitResult;
+use crate::kernel::standard::link_rename;
 
 pub fn enter() -> Result<()> {
     Ok(())

--- a/src/kernel/standard/standard_syscall.rs
+++ b/src/kernel/standard/standard_syscall.rs
@@ -1,4 +1,4 @@
-use errors::Result;
+use crate::errors::Result;
 
 pub fn enter() -> Result<()> {
     Ok(())

--- a/src/kernel/standard/stat_at.rs
+++ b/src/kernel/standard/stat_at.rs
@@ -1,4 +1,4 @@
-use errors::Result;
+use crate::errors::Result;
 
 pub fn enter() -> Result<()> {
     Ok(())

--- a/src/kernel/standard/sym_link.rs
+++ b/src/kernel/standard/sym_link.rs
@@ -1,4 +1,4 @@
-use errors::Result;
+use crate::errors::Result;
 
 pub fn enter() -> Result<()> {
     Ok(())

--- a/src/kernel/standard/sym_link_at.rs
+++ b/src/kernel/standard/sym_link_at.rs
@@ -1,4 +1,4 @@
-use errors::Result;
+use crate::errors::Result;
 
 pub fn enter() -> Result<()> {
     Ok(())

--- a/src/kernel/standard/uname.rs
+++ b/src/kernel/standard/uname.rs
@@ -1,4 +1,4 @@
-use kernel::exit::SyscallExitResult;
+use crate::kernel::exit::SyscallExitResult;
 
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 pub fn exit() -> SyscallExitResult {

--- a/src/kernel/standard/unlink_mkdir_at.rs
+++ b/src/kernel/standard/unlink_mkdir_at.rs
@@ -1,4 +1,4 @@
-use errors::Result;
+use crate::errors::Result;
 
 pub fn enter() -> Result<()> {
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,9 +17,9 @@ mod process;
 mod register;
 mod utils;
 
-use filesystem::{FileSystem, Initialiser};
-use process::proot::{show_info, stop_program, PRoot};
-use process::sigactions;
+use crate::filesystem::{FileSystem, Initialiser};
+use crate::process::proot::{show_info, stop_program, PRoot};
+use crate::process::sigactions;
 use std::process::exit;
 
 fn main() {

--- a/src/process/event.rs
+++ b/src/process/event.rs
@@ -1,7 +1,7 @@
+use crate::process::proot::InfoBag;
+use crate::process::tracee::{Tracee, TraceeRestartMethod, TraceeStatus};
+use crate::process::translation::SyscallTranslator;
 use nix::sys::signal::Signal;
-use process::proot::InfoBag;
-use process::tracee::{Tracee, TraceeRestartMethod, TraceeStatus};
-use process::translation::SyscallTranslator;
 
 //TODO: remove this when a nix PR will have added them
 mod ptrace_events {

--- a/src/process/event.rs
+++ b/src/process/event.rs
@@ -1,87 +1,20 @@
 use crate::process::proot::InfoBag;
 use crate::process::tracee::{Tracee, TraceeRestartMethod, TraceeStatus};
 use crate::process::translation::SyscallTranslator;
+use nix::sys::ptrace::Event as PtraceEvent;
 use nix::sys::signal::Signal;
 
-//TODO: remove this when a nix PR will have added them
-mod ptrace_events {
-    use libc::{c_int, SIGSTOP, SIGTRAP};
-    use nix::sys::ptrace::ptrace::*;
-
-    pub type PtraceSignalEvent = c_int;
-
-    pub const PTRACE_S_SIGSTOP: PtraceSignalEvent = SIGSTOP;
-    pub const PTRACE_S_RAW_SIGTRAP: PtraceSignalEvent = SIGTRAP;
-    pub const PTRACE_S_NORMAL_SIGTRAP: PtraceSignalEvent = SIGTRAP | 0x80;
-    pub const PTRACE_S_VFORK: PtraceSignalEvent = SIGTRAP | PTRACE_EVENT_VFORK << 8;
-    pub const PTRACE_S_VFORK_DONE: PtraceSignalEvent = SIGTRAP | PTRACE_EVENT_VFORK_DONE << 8;
-    pub const PTRACE_S_FORK: PtraceSignalEvent = SIGTRAP | PTRACE_EVENT_FORK << 8;
-    pub const PTRACE_S_CLONE: PtraceSignalEvent = SIGTRAP | PTRACE_EVENT_CLONE << 8;
-    pub const PTRACE_S_EXEC: PtraceSignalEvent = SIGTRAP | PTRACE_EVENT_EXEC << 8;
-    pub const PTRACE_S_SECCOMP: PtraceSignalEvent = SIGTRAP | PTRACE_EVENT_SECCOMP << 8;
-    pub const PTRACE_S_SECCOMP2: PtraceSignalEvent = SIGTRAP | (PTRACE_EVENT_SECCOMP + 1) << 8;
-    // unreachable pattern?
-    // pub const EXIT_SIGNAL:               PTraceSignalEvent = SIGTRAP | PTRACE_EVENT_EXIT << 8;
-}
-use self::ptrace_events::*;
-
 pub trait EventHandler {
-    fn handle_event(&mut self, info_bag: &mut InfoBag, stop_signal: Option<Signal>);
-    fn handle_sigtrap_event(&mut self, info_bag: &mut InfoBag, signal: PtraceSignalEvent);
+    fn handle_syscall_stop_event(&mut self, info_bag: &mut InfoBag);
     fn handle_sigstop_event(&mut self);
-    fn handle_seccomp_event(&mut self, info_bag: &mut InfoBag, signal: PtraceSignalEvent);
+    fn handle_seccomp_event(&mut self, info_bag: &mut InfoBag, event: PtraceEvent);
     fn handle_exec_vfork_event(&mut self);
-    fn handle_new_child_event(&mut self, event: PtraceSignalEvent);
+    fn handle_new_child_event(&mut self, event: PtraceEvent);
 }
 
 impl EventHandler for Tracee {
-    /// The traced process is stopped; this function will either:
-    /// 1. in case of standard syscall: translate the system call's parameters and restart it
-    /// 2. in case of fork/clone event: create a new tracee
-    /// 3. in other cases: not much
-    fn handle_event(&mut self, info_bag: &mut InfoBag, stop_signal: Option<Signal>) {
-        let signal: PtraceSignalEvent = match stop_signal {
-            Some(sig) => sig as PtraceSignalEvent,
-            None => PTRACE_S_NORMAL_SIGTRAP,
-        };
-
-        // the restart method might already have been set elsewhere
-        if self.restart_how == TraceeRestartMethod::None {
-            // When seccomp is enabled, all events are restarted in
-            // non-stop mode, but this default choice could be overwritten
-            // later if necessary.  The check against "sysexit_pending"
-            // ensures WithExitStage/PTRACE_SYSCALL (used to hit the exit stage under
-            // seccomp) is not cleared due to an event that would happen
-            // before the exit stage, eg. PTRACE_EVENT_EXEC for the exit
-            // stage of kernel.execve(2).
-            if self.seccomp && !self.sysexit_pending {
-                self.restart_how = TraceeRestartMethod::WithoutExitStage;
-            } else {
-                self.restart_how = TraceeRestartMethod::WithExitStage;
-            }
-        }
-
-        match signal {
-            PTRACE_S_RAW_SIGTRAP | PTRACE_S_NORMAL_SIGTRAP => {
-                self.handle_sigtrap_event(info_bag, signal)
-            }
-            PTRACE_S_SECCOMP | PTRACE_S_SECCOMP2 => self.handle_seccomp_event(info_bag, signal),
-            PTRACE_S_VFORK | PTRACE_S_FORK | PTRACE_S_CLONE => self.handle_new_child_event(signal),
-            PTRACE_S_EXEC | PTRACE_S_VFORK_DONE => self.handle_exec_vfork_event(),
-            PTRACE_S_SIGSTOP => self.handle_sigstop_event(),
-            _ => {}
-        }
-    }
-
-    /// Standard handling of either:
-    /// 1. the initial SIGTRAP signal
-    /// 2. a syscall that is then translated
-    fn handle_sigtrap_event(&mut self, info_bag: &mut InfoBag, signal: PtraceSignalEvent) {
-        if signal == PTRACE_S_RAW_SIGTRAP {
-            // it's the initial SIGTRAP signal
-            self.set_ptrace_options(info_bag);
-        }
-
+    /// Standard handling of syscall-stop: translate the system call's parameters and restart it
+    fn handle_syscall_stop_event(&mut self, info_bag: &mut InfoBag) {
         /* This tracee got signaled then freed during the
         sysenter stage but the kernel reports the sysexit
         stage; just discard this spurious tracee/event. */
@@ -119,7 +52,7 @@ impl EventHandler for Tracee {
         // }
     }
 
-    fn handle_seccomp_event(&mut self, info_bag: &mut InfoBag, signal: PtraceSignalEvent) {
+    fn handle_seccomp_event(&mut self, info_bag: &mut InfoBag, signal: PtraceEvent) {
         println!("seccomp event! {:?}, {:?}", info_bag, signal);
     }
 
@@ -127,7 +60,7 @@ impl EventHandler for Tracee {
         println!("EXEC or VFORK event");
     }
 
-    fn handle_new_child_event(&mut self, event: PtraceSignalEvent) {
+    fn handle_new_child_event(&mut self, event: PtraceEvent) {
         println!("new child: {:?}", event);
     }
 }

--- a/src/process/proot.rs
+++ b/src/process/proot.rs
@@ -1,7 +1,7 @@
-use filesystem::temp::TempFile;
-use filesystem::FileSystem;
-use process::event::EventHandler;
-use process::tracee::Tracee;
+use crate::filesystem::temp::TempFile;
+use crate::filesystem::FileSystem;
+use crate::process::event::EventHandler;
+use crate::process::tracee::Tracee;
 use std::collections::HashMap;
 use std::ffi::CString;
 use std::ptr::null_mut;

--- a/src/process/sigactions.rs
+++ b/src/process/sigactions.rs
@@ -1,8 +1,8 @@
 // signals
 use libc::{c_int, c_void, pid_t, siginfo_t};
+use nix::sys::signal::SaFlags;
 use nix::sys::signal::Signal::*;
 use nix::sys::signal::{sigaction, SigAction, SigHandler, SigSet, Signal};
-use nix::sys::signal::{SaFlags, SA_RESTART, SA_SIGINFO};
 
 /// Configures the actions associated with specific critical signals.
 /// All signals are blocked when the signal handler is called.
@@ -13,7 +13,7 @@ pub fn prepare_sigactions(
     let signal_set: SigSet = SigSet::all();
     // SIGINFO is used to know which process has signaled us and
     // RESTART is used to restart waitpid(2) seamlessly.
-    let sa_flags: SaFlags = SA_SIGINFO | SA_RESTART;
+    let sa_flags: SaFlags = SaFlags::SA_SIGINFO | SaFlags::SA_RESTART;
 
     for signal in Signal::iterator() {
         let mut signal_handler: SigHandler = SigHandler::SigIgn; // default action is ignoring

--- a/src/process/tracee.rs
+++ b/src/process/tracee.rs
@@ -2,12 +2,9 @@ use crate::errors::Error;
 use crate::filesystem::FileSystem;
 use crate::process::proot::InfoBag;
 use crate::register::Registers;
-use nix::sys::ptrace::ptrace;
-use nix::sys::ptrace::ptrace::*;
-use nix::sys::ptrace::ptrace_setoptions;
+use nix::sys::ptrace::{self, Options};
 use nix::unistd::Pid;
 use std::path::PathBuf;
-use std::ptr::null_mut;
 
 #[derive(Debug, PartialEq)]
 pub enum TraceeStatus {
@@ -84,15 +81,32 @@ impl Tracee {
     }
 
     #[inline]
+    pub fn reset_restart_how(&mut self) {
+        // the restart method might already have been set elsewhere
+        if self.restart_how == TraceeRestartMethod::None {
+            // When seccomp is enabled, all events are restarted in
+            // non-stop mode, but this default choice could be overwritten
+            // later if necessary.  The check against "sysexit_pending"
+            // ensures WithExitStage/PTRACE_SYSCALL (used to hit the exit stage under
+            // seccomp) is not cleared due to an event that would happen
+            // before the exit stage, eg. PTRACE_EVENT_EXEC for the exit
+            // stage of kernel.execve(2).
+            if self.seccomp && !self.sysexit_pending {
+                self.restart_how = TraceeRestartMethod::WithoutExitStage;
+            } else {
+                self.restart_how = TraceeRestartMethod::WithExitStage;
+            }
+        }
+    }
+
+    #[inline]
     pub fn restart(&mut self) {
         match self.restart_how {
             TraceeRestartMethod::WithoutExitStage => {
-                ptrace(PTRACE_CONT, self.pid, null_mut(), null_mut())
-                    .expect("exit tracee without exit stage");
+                ptrace::cont(self.pid, None).expect("exit tracee without exit stage");
             }
             TraceeRestartMethod::WithExitStage => {
-                ptrace(PTRACE_SYSCALL, self.pid, null_mut(), null_mut())
-                    .expect("exit tracee with exit stage");
+                ptrace::syscall(self.pid, None).expect("exit tracee with exit stage");
             }
             TraceeRestartMethod::None => {}
         };
@@ -116,16 +130,16 @@ impl Tracee {
             info_bag.deliver_sigtrap = true;
         }
 
-        let default_options = PTRACE_O_TRACESYSGOOD
-            | PTRACE_O_TRACEFORK
-            | PTRACE_O_TRACEVFORK
-            | PTRACE_O_TRACEVFORKDONE
-            | PTRACE_O_TRACEEXEC
-            | PTRACE_O_TRACECLONE
-            | PTRACE_O_TRACEEXIT;
+        let default_options = Options::PTRACE_O_TRACESYSGOOD
+            | Options::PTRACE_O_TRACEFORK
+            | Options::PTRACE_O_TRACEVFORK
+            | Options::PTRACE_O_TRACEVFORKDONE
+            | Options::PTRACE_O_TRACEEXEC
+            | Options::PTRACE_O_TRACECLONE
+            | Options::PTRACE_O_TRACEEXIT;
 
         //TODO: seccomp
-        ptrace_setoptions(self.pid, default_options).expect("set ptrace options");
+        ptrace::setoptions(self.pid, default_options).expect("set ptrace options");
     }
 }
 

--- a/src/process/tracee.rs
+++ b/src/process/tracee.rs
@@ -1,11 +1,11 @@
-use errors::Error;
-use filesystem::FileSystem;
+use crate::errors::Error;
+use crate::filesystem::FileSystem;
+use crate::process::proot::InfoBag;
+use crate::register::Registers;
 use nix::sys::ptrace::ptrace;
 use nix::sys::ptrace::ptrace::*;
 use nix::sys::ptrace::ptrace_setoptions;
 use nix::unistd::Pid;
-use process::proot::InfoBag;
-use register::Registers;
 use std::path::PathBuf;
 use std::ptr::null_mut;
 
@@ -132,9 +132,9 @@ impl Tracee {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use filesystem::FileSystem;
+    use crate::filesystem::FileSystem;
+    use crate::utils::tests::fork_test;
     use nix::unistd::Pid;
-    use utils::tests::fork_test;
 
     #[test]
     fn create_tracee() {

--- a/src/process/translation.rs
+++ b/src/process/translation.rs
@@ -1,7 +1,7 @@
-use kernel::{enter, exit};
-use process::proot::InfoBag;
-use process::tracee::{Tracee, TraceeRestartMethod, TraceeStatus};
-use register::{Modified, Original, StackPointer, SysResult, Word};
+use crate::kernel::{enter, exit};
+use crate::process::proot::InfoBag;
+use crate::process::tracee::{Tracee, TraceeRestartMethod, TraceeStatus};
+use crate::register::{Modified, Original, StackPointer, SysResult, Word};
 
 pub trait SyscallTranslator {
     fn translate_syscall(&mut self, info_bag: &InfoBag);

--- a/src/register/mem.rs
+++ b/src/register/mem.rs
@@ -1,5 +1,5 @@
-use errors::{Error, Result};
-use register::{Current, Original, Registers, StackPointer, Word};
+use crate::errors::{Error, Result};
+use crate::register::{Current, Original, Registers, StackPointer, Word};
 use std::usize::MAX as USIZE_MAX;
 
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
@@ -67,9 +67,9 @@ impl PtraceMemoryAllocator for Registers {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::register::Registers;
     use libc::user_regs_struct;
     use nix::unistd::getpid;
-    use register::Registers;
     use std::mem;
     use std::usize::MAX;
 

--- a/src/register/reader.rs
+++ b/src/register/reader.rs
@@ -1,10 +1,10 @@
-use errors::Error;
-use errors::Result;
+use crate::errors::Error;
+use crate::errors::Result;
+use crate::register::{Current, Registers, SysArg, SysArgIndex, Word};
 use libc::{c_void, PATH_MAX};
 use nix::sys::ptrace::ptrace;
 use nix::sys::ptrace::ptrace::PTRACE_PEEKDATA;
 use nix::unistd::Pid;
-use register::{Current, Registers, SysArg, SysArgIndex, Word};
 use std::mem::{size_of, transmute};
 use std::path::PathBuf;
 use std::ptr::null_mut;
@@ -133,13 +133,13 @@ fn read_string(pid: Pid, src_string: *mut Word, max_size: usize) -> Result<Vec<u
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::register::*;
+    use crate::utils::tests::fork_test;
     use libc::user_regs_struct;
     use nix::unistd::{execvp, getpid};
-    use register::*;
     use sc::nr::MKDIR;
     use std::ffi::CString;
     use std::mem;
-    use utils::tests::fork_test;
 
     #[test]
     #[cfg(target_pointer_width = "64")]

--- a/src/register/reader.rs
+++ b/src/register/reader.rs
@@ -2,12 +2,10 @@ use crate::errors::Error;
 use crate::errors::Result;
 use crate::register::{Current, Registers, SysArg, SysArgIndex, Word};
 use libc::{c_void, PATH_MAX};
-use nix::sys::ptrace::ptrace;
-use nix::sys::ptrace::ptrace::PTRACE_PEEKDATA;
+use nix::sys::ptrace;
 use nix::unistd::Pid;
 use std::mem::{size_of, transmute};
 use std::path::PathBuf;
-use std::ptr::null_mut;
 
 #[cfg(target_pointer_width = "32")]
 #[inline]
@@ -90,7 +88,7 @@ fn read_string(pid: Pid, src_string: *mut Word, max_size: usize) -> Result<Vec<u
         let src_addr = unsafe { src_string.offset(i) as *mut c_void };
 
         // ptrace returns a c_long/Word that we will interpret as an 8-letters word
-        let word = ptrace(PTRACE_PEEKDATA, pid, src_addr, null_mut())? as Word;
+        let word = ptrace::read(pid, src_addr)? as Word;
         let letters = convert_word_to_bytes(word);
 
         for &letter in &letters {

--- a/src/register/regs.rs
+++ b/src/register/regs.rs
@@ -1,9 +1,9 @@
-use errors::Result;
+use crate::errors::Result;
+use crate::register::Word;
 use libc::{c_void, user_regs_struct};
 use nix::sys::ptrace::ptrace;
 use nix::sys::ptrace::ptrace::{PTRACE_GETREGS, PTRACE_SETREGS};
 use nix::unistd::Pid;
-use register::Word;
 use std::fmt;
 use std::mem;
 use std::ptr::null_mut;
@@ -323,10 +323,10 @@ impl fmt::Display for Registers {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::utils::tests::fork_test;
     use nix::unistd::{execvp, Pid};
     use sc::nr::{CLOCK_NANOSLEEP, NANOSLEEP};
     use std::ffi::CString;
-    use utils::tests::fork_test;
 
     #[test]
     fn test_regs_where_changed() {

--- a/src/register/writer.rs
+++ b/src/register/writer.rs
@@ -1,10 +1,10 @@
+use crate::errors::Result;
+use crate::register::reader::convert_word_to_bytes;
+use crate::register::{PtraceMemoryAllocator, Registers, SysArg, SysArgIndex, Word};
 use byteorder::{LittleEndian, ReadBytesExt};
-use errors::Result;
 use libc::c_void;
 use nix::sys::ptrace::ptrace;
 use nix::sys::ptrace::ptrace::{PTRACE_PEEKDATA, PTRACE_POKEDATA};
-use register::reader::convert_word_to_bytes;
-use register::{PtraceMemoryAllocator, Registers, SysArg, SysArgIndex, Word};
 use std::io::Cursor;
 use std::io::Read;
 use std::mem;
@@ -131,12 +131,12 @@ impl PtraceWriter for Registers {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::register::{Current, Original, PtraceReader, SysArg1};
+    use crate::utils::tests::fork_test;
     use nix::unistd::execvp;
-    use register::{Current, Original, PtraceReader, SysArg1};
     use sc::nr::MKDIR;
     use std::ffi::CString;
     use std::path::PathBuf;
-    use utils::tests::fork_test;
 
     #[test]
     fn test_write_set_sysarg_path_write_same_path() {

--- a/src/register/writer.rs
+++ b/src/register/writer.rs
@@ -3,8 +3,7 @@ use crate::register::reader::convert_word_to_bytes;
 use crate::register::{PtraceMemoryAllocator, Registers, SysArg, SysArgIndex, Word};
 use byteorder::{LittleEndian, ReadBytesExt};
 use libc::c_void;
-use nix::sys::ptrace::ptrace;
-use nix::sys::ptrace::ptrace::{PTRACE_PEEKDATA, PTRACE_POKEDATA};
+use nix::sys::ptrace;
 use std::io::Cursor;
 use std::io::Read;
 use std::mem;
@@ -92,19 +91,13 @@ impl PtraceWriter for Registers {
             let word = buf.read_uint::<LittleEndian>(word_size).unwrap() as Word;
             let dest_addr = unsafe { dest_tracee.offset(i) as *mut c_void };
 
-            ptrace(
-                PTRACE_POKEDATA,
-                self.get_pid(),
-                dest_addr,
-                word as *mut c_void,
-            )?;
+            unsafe { ptrace::write(self.get_pid(), dest_addr, word as *mut c_void)? };
         }
 
         // Copy the bytes in the last word carefully since we have to
         // overwrite only the relevant ones.
         let last_dest_addr = unsafe { dest_tracee.offset(nb_full_words) as *mut c_void };
-        let existing_word =
-            ptrace(PTRACE_PEEKDATA, self.get_pid(), last_dest_addr, null_mut())? as Word;
+        let existing_word = ptrace::read(self.get_pid(), last_dest_addr)? as Word;
         let mut bytes = convert_word_to_bytes(existing_word);
 
         // The trailing bytes are merged with the existing bytes. For example:
@@ -117,12 +110,7 @@ impl PtraceWriter for Registers {
 
         let last_word = convert_bytes_to_word(bytes);
         // We can now safely write the final word.
-        ptrace(
-            PTRACE_POKEDATA,
-            self.get_pid(),
-            last_dest_addr,
-            last_word as *mut c_void,
-        )?;
+        unsafe { ptrace::write(self.get_pid(), last_dest_addr, last_word as *mut c_void)? };
 
         Ok(())
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,25 +3,22 @@ pub mod tests {
     use crate::filesystem::FileSystem;
     use crate::process::proot::InfoBag;
     use crate::process::tracee::Tracee;
-    use nix::sys::ptrace::ptrace;
-    use nix::sys::ptrace::ptrace::PTRACE_SYSCALL;
-    use nix::sys::ptrace::ptrace::PTRACE_TRACEME;
     use nix::sys::signal::kill;
     use nix::sys::signal::Signal::SIGSTOP;
+    use nix::sys::wait;
     use nix::sys::wait::WaitStatus::*;
-    use nix::sys::wait::{waitpid, __WALL};
+    use nix::sys::{ptrace, wait::WaitPidFlag};
     use nix::unistd::{fork, getpid, ForkResult, Pid};
-    use std::ptr::null_mut;
 
     /// Allow tests to fork and deal with child processes without mixing them.
     fn test_in_subprocess<F: FnMut()>(mut func: F) {
-        let pid = fork();
+        let pid = unsafe { fork() };
         match pid {
             Ok(ForkResult::Child) => {
                 func();
             }
             Ok(ForkResult::Parent { child }) => {
-                assert_eq!(waitpid(child, None), Ok(Exited(child, 0)))
+                assert_eq!(wait::waitpid(child, None), Ok(Exited(child, 0)))
             }
             Err(_) => panic!("Error: fork"),
         }
@@ -38,14 +35,15 @@ pub mod tests {
         mut func_child: FuncChild,
     ) {
         test_in_subprocess(|| {
-            match fork().expect("fork in test") {
+            match unsafe { fork() }.expect("fork in test") {
                 ForkResult::Parent { child } => {
                     let mut info_bag = InfoBag::new();
                     let mut tracee = Tracee::new(child, FileSystem::with_root(fs_root));
 
                     // the parent will wait for the child's signal before calling set_ptrace_options
                     assert_eq!(
-                        waitpid(child, Some(__WALL)).expect("event loop waitpid"),
+                        wait::waitpid(child, Some(WaitPidFlag::__WALL))
+                            .expect("event loop waitpid"),
                         Stopped(child, SIGSTOP)
                     );
                     tracee.set_ptrace_options(&mut info_bag);
@@ -54,7 +52,9 @@ pub mod tests {
 
                     // we loop until the parent function decides to stop
                     loop {
-                        match waitpid(child, Some(__WALL)).expect("event loop waitpid") {
+                        match wait::waitpid(child, Some(WaitPidFlag::__WALL))
+                            .expect("event loop waitpid")
+                        {
                             PtraceSyscall(pid) => {
                                 assert_eq!(pid, child);
                                 tracee.regs.fetch_regs().expect("fetch regs");
@@ -74,8 +74,7 @@ pub mod tests {
                     end(child, expected_exit_signal);
                 }
                 ForkResult::Child => {
-                    ptrace(PTRACE_TRACEME, Pid::from_raw(0), null_mut(), null_mut())
-                        .expect("test ptrace traceme");
+                    ptrace::traceme().expect("test ptrace traceme");
                     // we use a SIGSTOP to synchronise both processes
                     kill(getpid(), SIGSTOP).expect("test child sigstop");
 
@@ -87,18 +86,18 @@ pub mod tests {
 
     /// Restarts a child process just once.
     fn restart(child: Pid) {
-        ptrace(PTRACE_SYSCALL, child, null_mut(), null_mut()).expect("exit tracee with exit stage");
+        ptrace::syscall(child, None).expect("exit tracee with exit stage");
     }
 
     /// Waits/restarts a child process until it stops.
     fn end(child: Pid, expected_status: i8) {
         loop {
-            match waitpid(child, Some(__WALL)).expect("waitpid") {
+            match wait::waitpid(child, Some(WaitPidFlag::__WALL)).expect("waitpid") {
                 Exited(pid, exit_status) => {
                     assert_eq!(pid, child);
 
                     // the tracee should have exited with the expected status
-                    assert_eq!(exit_status, expected_status);
+                    assert_eq!(exit_status as i8, expected_status);
                     break;
                 }
                 _ => {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,8 @@
 #[cfg(test)]
 pub mod tests {
-    use filesystem::FileSystem;
+    use crate::filesystem::FileSystem;
+    use crate::process::proot::InfoBag;
+    use crate::process::tracee::Tracee;
     use nix::sys::ptrace::ptrace;
     use nix::sys::ptrace::ptrace::PTRACE_SYSCALL;
     use nix::sys::ptrace::ptrace::PTRACE_TRACEME;
@@ -9,8 +11,6 @@ pub mod tests {
     use nix::sys::wait::WaitStatus::*;
     use nix::sys::wait::{waitpid, __WALL};
     use nix::unistd::{fork, getpid, ForkResult, Pid};
-    use process::proot::InfoBag;
-    use process::tracee::Tracee;
     use std::ptr::null_mut;
 
     /// Allow tests to fork and deal with child processes without mixing them.


### PR DESCRIPTION
This PR did the following things:

- Transition project to Rust [2018 edition](https://doc.rust-lang.org/edition-guide/rust-2018/index.html)
- Specify the toolchain version as `nightly-nightly-2021-03-24`, for the consistency of the development and CI test environment.
- Increase nix version to 0.20.0 and rewrite eventloop, because the newer nix has realized [nix::sys::ptrace::Event](https://docs.rs/nix/0.20.0/nix/sys/ptrace/enum.Event.html)