### PR TITLE
Read command from cli

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,7 +27,7 @@ jobs:
           before_commit=${{ github.event.pull_request.base.sha }}
         else # is push event
           if [ "${{ github.event.before }}" = "0000000000000000000000000000000000000000" ]; then
-            before_commit="HEAD~1"
+            before_commit="$(git rev-parse HEAD~1)"
           else
             before_commit=${{ github.event.before }}
           fi

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,7 +7,9 @@ use std::path::PathBuf;
 pub const DEFAULT_ROOTFS: &'static str = "/";
 pub const DEFAULT_CWD: &'static str = ".";
 
-pub fn parse_config(fs: &mut FileSystem) {
+pub fn parse_config() -> (FileSystem, Vec<String>) {
+    let mut fs: FileSystem = FileSystem::new();
+
     let matches = App::new("proot-rsc")
         .arg(Arg::with_name("rootfs")
             .short("r")
@@ -29,7 +31,11 @@ pub fn parse_config(fs: &mut FileSystem) {
             .help("Set the initial working directory to *path*.")
             .takes_value(true)
             .default_value(DEFAULT_CWD))
+        .arg(Arg::with_name("command")
+            .multiple(true))
         .get_matches();
+
+    dbg!(&matches);
 
     // option -r
     let rootfs: &str = matches.value_of("rootfs").unwrap();
@@ -49,4 +55,12 @@ pub fn parse_config(fs: &mut FileSystem) {
     // option -w
     let cwd: &str = matches.value_of("cwd").unwrap();
     fs.set_cwd(PathBuf::from(cwd));
+
+    // command
+    let command: Vec<String> = match matches.values_of("command") {
+        Some(values) => values.map(|s| s.into()).collect(),
+        None => ["/bin/sh".into()].into(),
+    };
+
+    (fs, command)
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -35,7 +35,7 @@ pub fn parse_config() -> (FileSystem, Vec<String>) {
             .multiple(true))
         .get_matches();
 
-    dbg!(&matches);
+    debug!("proot-rs startup with args:\n{:#?}", matches);
 
     // option -r
     let rootfs: &str = matches.value_of("rootfs").unwrap();

--- a/src/filesystem/initialization.rs
+++ b/src/filesystem/initialization.rs
@@ -34,12 +34,12 @@ impl Initialiser for FileSystem {
             Ok(path) => path,
             Err(err) => {
                 //TODO: log error
-                eprintln!(
-                    "proot warning: can't chdir (\"{}\") in the guest rootfs: {}",
+                warn!(
+                    "can't chdir (\"{}\") in the guest rootfs: {}",
                     raw_cwd.display(),
                     err
                 );
-                println!("proot info: default working directory is now \"/\"");
+                info!("default working directory is now \"/\"");
                 PathBuf::from("/")
             }
         };

--- a/src/kernel/exit.rs
+++ b/src/kernel/exit.rs
@@ -25,7 +25,7 @@ pub fn translate(tracee: &mut Tracee) {
     let syscall_number = tracee.regs.get_sys_num(Current);
     let syscall_group = syscall_group_from_sysnum(syscall_number);
 
-    println!("exit  \t({:?}, \t{:?})", syscall_number, syscall_group);
+    debug!("Syscall exit ({:?}, {:?})", syscall_number, syscall_group);
 
     let result = match syscall_group {
         SyscallGroup::Brk => brk::exit(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,9 +28,8 @@ use std::process::exit;
 
 fn run() -> Result<()> {
     // step 1: CLI parsing
-    let mut fs: FileSystem = FileSystem::new();
 
-    cli::parse_config(&mut fs);
+    let (mut fs, command) = cli::parse_config();
 
     if let Err(error) = fs.initialize() {
         error!("Error during file system initialization: {}", error);
@@ -40,7 +39,7 @@ fn run() -> Result<()> {
     let mut proot: PRoot = PRoot::new();
 
     // step 2: Start the first tracee
-    proot.launch_process(fs);
+    proot.launch_process(fs, command)?;
 
     // what follows (event loop) is only for the main thread,
     // as the child thread will stop after executing the `kernel.execve` command

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,9 +48,9 @@ fn run() -> Result<()> {
     sigactions::prepare_sigactions(stop_program, show_info);
 
     // step 4: Listen to and deal with tracees events
-    proot.event_loop();
+    proot.event_loop()?;
 
-    println!("{:#?}", proot);
+    debug!("proot-rs exit with final status:\n{:#?}", proot);
 
     Ok(())
 }

--- a/src/process/event.rs
+++ b/src/process/event.rs
@@ -42,7 +42,7 @@ impl EventHandler for Tracee {
     }
 
     fn handle_sigstop_event(&mut self) {
-        println!("sigstop! {}", self.pid);
+        debug!("sigstop! {}", self.pid);
 
         // Stop this tracee until PRoot has received
         // the EVENT_*FORK|CLONE notification.
@@ -54,14 +54,14 @@ impl EventHandler for Tracee {
     }
 
     fn handle_seccomp_event(&mut self, info_bag: &mut InfoBag, signal: PtraceEvent) {
-        println!("seccomp event! {:?}, {:?}", info_bag, signal);
+        debug!("seccomp event! {:?}, {:?}", info_bag, signal);
     }
 
     fn handle_exec_vfork_event(&mut self) {
-        println!("EXEC or VFORK event");
+        debug!("EXEC or VFORK event");
     }
 
     fn handle_new_child_event(&mut self, event: PtraceEvent) {
-        println!("new child: {:?}", event);
+        debug!("new child: {:?}", event);
     }
 }

--- a/src/process/sigactions.rs
+++ b/src/process/sigactions.rs
@@ -41,7 +41,7 @@ pub fn prepare_sigactions(
         let sigaction_result = unsafe { sigaction(signal, &signal_action) };
 
         if let Err(err) = sigaction_result {
-            println!(
+            warn!(
                 "Warning: sigaction failed for signal {:?} : {:?}.",
                 signal, err
             );

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -56,7 +56,9 @@ pub mod tests {
                             .expect("event loop waitpid"),
                         Stopped(child, SIGSTOP)
                     );
-                    tracee.set_ptrace_options(&mut info_bag);
+                    tracee
+                        .check_and_set_ptrace_options(&mut info_bag)
+                        .expect("error when set ptrace options");
 
                     restart(child);
 


### PR DESCRIPTION
This PR is a part of https://github.com/proot-me/proot-rs/issues/23 and has done the following things:

- make proot-rs to read command from cli
- set ptrace options on the arrival of the first SIGSTOP instead of SIGTRAP


example to run `/bin/sleep`: 
```
cargo run -- --rootfs=./rootfs /bin/sleep 3
# or use this with log level set to `trace`
RUST_LOG=trace cargo run -- --rootfs=./rootfs /bin/sleep 3
```
