### PR TITLE
Implement test_with_proot() for unit tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -65,4 +65,4 @@ jobs:
         # Setup rootfs
         bash scripts/mkrootfs.sh
         # Run cargo test
-        PROOT_TEST_ROOTFS=./rootfs cargo test --verbose -- --test-threads=1 --nocapture
+        PROOT_TEST_ROOTFS=./rootfs cargo test --verbose -- --nocapture

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -65,4 +65,4 @@ jobs:
         # Setup rootfs
         bash scripts/mkrootfs.sh
         # Run cargo test
-        PROOT_TEST_ROOTFS=./rootfs cargo test --verbose
+        PROOT_TEST_ROOTFS=./rootfs cargo test --verbose -- --test-threads=1 --nocapture

--- a/README.md
+++ b/README.md
@@ -89,8 +89,7 @@ export PROOT_TEST_ROOTFS=/
 Start running tests:
 
 ```shell
-# Limit the number of threads running the test case to 1 to avoid deadlock problems caused by using fork in a multi-threaded environment
-cargo test -- --test-threads=1
+cargo test
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -88,8 +88,9 @@ export PROOT_TEST_ROOTFS=/
 
 Start running tests:
 
-```
-cargo test
+```shell
+# Limit the number of threads running the test case to 1 to avoid deadlock problems caused by using fork in a multi-threaded environment
+cargo test -- --test-threads=1
 ```
 
 ## Contributing

--- a/src/filesystem/fs.rs
+++ b/src/filesystem/fs.rs
@@ -189,7 +189,7 @@ impl FileSystem {
 
     /// This function provides a way to check whether a path is canonical.
     ///
-    /// NOTE: This check **is not a strict check**. This function do not
+    /// NOTE: This check **is not a strict check**. This function does not
     /// dereference the final component of `path`, to allow for the case
     /// where the file does not exist but it's parent dir exists.
     #[cfg(test)]

--- a/src/filesystem/translation.rs
+++ b/src/filesystem/translation.rs
@@ -20,7 +20,7 @@ pub trait Translator {
 }
 
 impl Translator for FileSystem {
-    /// Translates a path from `guest` to `host`. Relative guest path are also
+    /// Translates a path from `guest` to `host`. Relative guest path is also
     /// accepted.
     fn translate_path<P: AsRef<Path>>(&self, guest_path: P, deref_final: bool) -> Result<PathBuf> {
         if guest_path.as_ref().is_relative() {
@@ -33,7 +33,7 @@ impl Translator for FileSystem {
         }
     }
 
-    /// Translates a path from `guest` to `host`. Relative guest path are also
+    /// Translates a path from `guest` to `host`. Only absolute guest path is
     /// accepted.
     fn translate_absolute_path<P: AsRef<Path>>(
         &self,

--- a/src/kernel/execve/enter.rs
+++ b/src/kernel/execve/enter.rs
@@ -121,9 +121,7 @@ mod tests {
             0,
             // parent
             |tracee, info_bag| {
-                if tracee.syscall_is_enter() {
-                    tracee.regs.save_current_regs(Original);
-                }
+                tracee.regs.save_current_regs(Original);
                 if tracee.regs.get_sys_num(Current) == EXECVE {
                     let dir_path = tracee.regs.get_sysarg_path(SysArg1).unwrap();
                     let file_exists = dir_path.exists();

--- a/src/process/proot.rs
+++ b/src/process/proot.rs
@@ -1,6 +1,7 @@
 use std::cell::RefCell;
 use std::ffi::CString;
 
+use std::marker::PhantomData;
 use std::process;
 use std::rc::Rc;
 use std::{collections::HashMap, convert::TryFrom};
@@ -252,7 +253,7 @@ impl PRoot {
                     tracee.reset_restart_how();
                     tracee.handle_syscall_stop_event(
                         &mut self.info_bag,
-                    #[cfg(test)]
+                        #[cfg(test)]
                         &self.func_syscall_hook,
                     );
                     tracee.restart(None);

--- a/src/process/tracee.rs
+++ b/src/process/tracee.rs
@@ -234,6 +234,19 @@ impl Tracee {
                 .translate_absolute_path(guest_path, deref_final)
         }
     }
+
+    /// Determine if the current syscall-stop is syscall-enter-stop or
+    /// syscall-exit-stop.
+    ///
+    /// Note that return value of this function is determined by tracee's
+    /// `status` field, so its value is only reliable reliable before
+    /// `translate_syscall()` is called.
+    pub fn syscall_is_enter(&self) -> bool {
+        match self.status {
+            TraceeStatus::SysEnter => true,
+            TraceeStatus::SysExit | TraceeStatus::Error(_) => false,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/register/regs.rs
+++ b/src/register/regs.rs
@@ -354,7 +354,7 @@ mod tests {
             || {
                 // calling the sleep function, which should call the NANOSLEEP syscall
                 execvp(
-                    &CString::new("sleep").unwrap(),
+                    &CString::new("/bin/sleep").unwrap(),
                     &[CString::new(".").unwrap(), CString::new("0").unwrap()],
                 )
                 .expect("failed execvp sleep");
@@ -377,12 +377,13 @@ mod tests {
             |tracee, _| {
                 // we only stop when the NANOSLEEP syscall is detected
                 tracee.regs.get_sys_num(Current) == NANOSLEEP
+                    || tracee.regs.get_sys_num(Current) == CLOCK_NANOSLEEP
             },
             // child
             || {
                 // calling the sleep function, which should call the NANOSLEEP syscall
                 execvp(
-                    &CString::new("sleep").unwrap(),
+                    &CString::new("/bin/sleep").unwrap(),
                     &[CString::new(".").unwrap(), CString::new("0").unwrap()],
                 )
                 .expect("failed execvp sleep");
@@ -432,7 +433,7 @@ mod tests {
             || {
                 // calling the sleep function, which should call the NANOSLEEP syscall
                 execvp(
-                    &CString::new("sleep").unwrap(),
+                    &CString::new("/bin/sleep").unwrap(),
                     &[CString::new(".").unwrap(), CString::new("9999").unwrap()],
                 )
                 .expect("failed execvp sleep");

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -27,8 +27,8 @@ pub mod tests {
 
     /// Allow tests to fork and deal with child processes without mixing them.
     ///
-    /// Since each rust unit tests is executed in a different thread, we'd
-    /// better to fork a child process to test the proot, otherwise the
+    /// Since each rust unit tests is executed in a different thread, we
+    /// should fork a child process to test the proot, otherwise the
     /// calls to `waitpid(-1)` from different unit tests may affect each other
     fn test_in_subprocess<F: FnOnce()>(func: F) {
         let pid = unsafe { fork() };


### PR DESCRIPTION
This PR is purely test-related:
- introduces a unit test helper function `test_with_proot()`.

After this we can write unit tests for each system call to test if syscall translation is correct.

`test_with_proot()` starts a regular proot-rs event loop and runs our tracee function, we can place some syscall in tracee function to simulate a normal tracee program. 
In addition, I extended the `struct Proot` by adding a `Fn` field to hold a callback function. In this callback function, we are able to check the internal state of proot-rs (e.g. by some `assert!()` statements).
Of course, all of the above are controlled by conditional compilation and are only enabled in unit tests.
