### PR TITLE
Fix trailing slash in link

### DIFF
--- a/tests/applets.bats
+++ b/tests/applets.bats
@@ -394,3 +394,30 @@ function script_test_should_not_follow {
     [ "$status" -eq 0 ]
 
 }
+
+
+
+function script_test_trailing_slash_in_symlink {
+    PATH=/bin
+
+    cd /tmp/test_trailing_slash_in_symlink
+
+    echo "hello world" > file
+    ln -s file link1
+    ln -s file/ link2
+    ln -s file/. link3
+
+    [[ "$(stat -L -c "%F" link1 2>&1)" == *"regular file"* ]]
+    [[ "$(stat -L -c "%F" link2 2>&1)" == *"Not a directory"* ]]
+    [[ "$(stat -L -c "%F" link3 2>&1)" == *"Not a directory"* ]]
+
+}
+
+@test "test trailing slash in symlink" {
+    local test_dir="$ROOTFS/tmp/test_trailing_slash_in_symlink"
+    mkdir "$test_dir"
+    runp proot-rs --rootfs "$ROOTFS" -- /bin/sh -e -x -c "$(declare -f script_test_trailing_slash_in_symlink); script_test_trailing_slash_in_symlink"
+    rm -rf "$test_dir"
+    [ "$status" -eq 0 ]
+
+}


### PR DESCRIPTION
This is an addition to the patches of https://github.com/proot-me/proot-rs/issues/41

The previous fix missed the handling of trailing slash in symbolic link files. 

In the following example, using `stat -L` to look at all these three symbolic link files would result in success. But the latter two should theoretically fail, since `file` is not a dir.
![image](https://user-images.githubusercontent.com/14936301/127258898-21543599-76d3-4472-8323-b7094e8df0e7.png)

This PR contains the corresponding fixes and test files