### PR TITLE
Add support for arm-unknown-linux-musleabi

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.arm-unknown-linux-musleabi]
+linker = "arm-linux-musleabi-gcc"

--- a/scripts/mkrootfs.sh
+++ b/scripts/mkrootfs.sh
@@ -25,7 +25,9 @@ case $(uname -m) in
     i386)   arch="i386" ;;
     i686)   arch="i386" ;;
     x86_64) arch="amd64" ;;
-    *)      echo "Unsupported architecture $(uname -m)"; exist 1 ;;
+    armv7l) arch="arm32v7" ;;
+    aarch64) arch="arm64v8" ;;
+    *)      echo "Unsupported architecture $(uname -m)"; exit 1 ;;
 esac
 
 if [ -n "$(ls -A "${PROOT_TEST_ROOTFS}" 2>/dev/null)" ]; then

--- a/src/build_loader.rs
+++ b/src/build_loader.rs
@@ -1,7 +1,7 @@
 extern crate gcc;
 
 #[cfg(target_arch = "x86")]
-mod config {
+mod arch {
     pub const LOADER_ADDRESS: u64 = 0xa0000000;
     pub const LOADER_ARCH_CFLAGS: &[&'static str] = &["-mregparm=3"];
 }

--- a/src/filesystem/ext.rs
+++ b/src/filesystem/ext.rs
@@ -146,7 +146,7 @@ mod tests {
 
                     // lstat("link1")
                     nc::lstat(&link1_name, &mut stat).unwrap();
-                    assert_eq!((stat.st_mode & nc::S_IFMT), nc::S_IFLNK);
+                    assert_eq!((stat.st_mode as nc::mode_t & nc::S_IFMT), nc::S_IFLNK);
 
                     // lstat("link1/")
                     assert_eq!(
@@ -156,11 +156,11 @@ mod tests {
 
                     // lstat("link2")
                     nc::lstat(&link2_name, &mut stat).unwrap();
-                    assert_eq!((stat.st_mode & nc::S_IFMT), nc::S_IFLNK);
+                    assert_eq!((stat.st_mode as nc::mode_t & nc::S_IFMT), nc::S_IFLNK);
 
                     // lstat("link2/")
                     nc::lstat(format!("{}/", link2_name).as_str(), &mut stat).unwrap();
-                    assert_eq!((stat.st_mode & nc::S_IFMT), nc::S_IFDIR);
+                    assert_eq!((stat.st_mode as nc::mode_t & nc::S_IFMT), nc::S_IFDIR);
                 });
 
                 let _ = std::fs::remove_dir_all(base_dir);
@@ -192,12 +192,12 @@ mod tests {
                     // mkdir("dir1"), test mkdir without trailing slash
                     nc::mkdir(&dir1_name, 0o755).unwrap();
                     nc::lstat(&dir1_name, &mut stat).unwrap();
-                    assert_eq!((stat.st_mode & nc::S_IFMT), nc::S_IFDIR);
+                    assert_eq!((stat.st_mode as nc::mode_t & nc::S_IFMT), nc::S_IFDIR);
 
                     // mkdir("dir2/"), test mkdir with trailing slash
                     nc::mkdir(format!("{}/", dir2_name).as_str(), 0o755).unwrap();
                     nc::lstat(format!("{}/", dir2_name).as_str(), &mut stat).unwrap();
-                    assert_eq!((stat.st_mode & nc::S_IFMT), nc::S_IFDIR);
+                    assert_eq!((stat.st_mode as nc::mode_t & nc::S_IFMT), nc::S_IFDIR);
 
                     nc::symlink(&dir3_name, &link1_name).unwrap();
 
@@ -248,15 +248,15 @@ mod tests {
 
                     // lstat("link1")
                     nc::lstat(&link1_name, &mut stat).unwrap();
-                    assert_eq!((stat.st_mode & nc::S_IFMT), nc::S_IFLNK);
+                    assert_eq!((stat.st_mode as nc::mode_t & nc::S_IFMT), nc::S_IFLNK);
 
                     // lstat("link2")
                     nc::lstat(&link2_name, &mut stat).unwrap();
-                    assert_eq!((stat.st_mode & nc::S_IFMT), nc::S_IFLNK);
+                    assert_eq!((stat.st_mode as nc::mode_t & nc::S_IFMT), nc::S_IFLNK);
 
                     // lstat("link1/") -> lstat("link2/") -> lstat("dir/")
                     nc::lstat(format!("{}/", link1_name).as_str(), &mut stat).unwrap();
-                    assert_eq!((stat.st_mode & nc::S_IFMT), nc::S_IFDIR);
+                    assert_eq!((stat.st_mode as nc::mode_t & nc::S_IFMT), nc::S_IFDIR);
                 });
 
                 let _ = std::fs::remove_dir_all(base_dir);

--- a/src/kernel/execve/load_info.rs
+++ b/src/kernel/execve/load_info.rs
@@ -306,7 +306,8 @@ impl LoadInfo {
 }
 
 // TODO: change size of enum tags
-#[repr(C, u64)]
+#[cfg_attr(any(target_arch = "x86_64", target_arch = "aarch64"), repr(C, u64))]
+#[cfg_attr(any(target_arch = "x86", target_arch = "arm"), repr(C, u32))]
 #[derive(Debug)]
 pub enum LoadStatement {
     OpenNext(LoadStatementOpen),

--- a/src/kernel/execve/loader/assembly-arm64.h
+++ b/src/kernel/execve/loader/assembly-arm64.h
@@ -20,12 +20,12 @@
  * 02110-1301 USA.
  */
 
-/* According to the ARM EABI, all registers have undefined values at
+/* According to the ARM64 EABI, all registers have undefined values at
  * program startup except:
  *
- * - the instruction pointer (r15)
- * - the stack pointer (r13)
- * - the rtld_fini pointer (r0)
+ * - the instruction pointer (pc)
+ * - the stack pointer (sp)
+ * - the rtld_fini pointer (x0)
  */
 #define BRANCH(stack_pointer, destination) do {			\
 	asm volatile (						\
@@ -33,29 +33,32 @@
 		"mov sp, %0				\n\t"	\
 		"					\n\t"	\
 		"// Clear rtld_fini.			\n\t"	\
-		"mov r0, #0				\n\t"	\
+		"mov x0, #0				\n\t"	\
 		"					\n\t"	\
 		"// Start the program.			\n\t"	\
-		"mov pc, %1				\n"	\
+		"br %1				\n"		\
 		: /* no output */				\
 		: "r" (stack_pointer), "r" (destination)	\
-		: "memory", "sp", "r0", "pc");			\
+		: "memory", "sp", "x0");			\
 	__builtin_unreachable();				\
 	} while (0)
 
 #define PREPARE_ARGS_1(arg1_)				\
-	register word_t arg1 asm("r0") = arg1_;		\
+	register word_t arg1 asm("x0") = arg1_;		\
 
 #define PREPARE_ARGS_3(arg1_, arg2_, arg3_)		\
 	PREPARE_ARGS_1(arg1_)				\
-	register word_t arg2 asm("r1") = arg2_;		\
-	register word_t arg3 asm("r2") = arg3_;		\
+	register word_t arg2 asm("x1") = arg2_;		\
+	register word_t arg3 asm("x2") = arg3_;		\
+
+#define PREPARE_ARGS_4(arg1_, arg2_, arg3_, arg4_)	\
+	PREPARE_ARGS_3(arg1_, arg2_, arg3_)		\
+	register word_t arg4 asm("x3") = arg4_;		\
 
 #define PREPARE_ARGS_6(arg1_, arg2_, arg3_, arg4_, arg5_, arg6_)	\
-	PREPARE_ARGS_3(arg1_, arg2_, arg3_)				\
-	register word_t arg4 asm("r3") = arg4_;				\
-	register word_t arg5 asm("r4") = arg5_;				\
-	register word_t arg6 asm("r5") = arg6_;
+	PREPARE_ARGS_4(arg1_, arg2_, arg3_, arg4_)			\
+	register word_t arg5 asm("x4") = arg5_;				\
+	register word_t arg6 asm("x5") = arg6_;
 
 #define OUTPUT_CONTRAINTS_1			\
 	"r" (arg1)
@@ -64,30 +67,32 @@
 	OUTPUT_CONTRAINTS_1,			\
 	"r" (arg2), "r" (arg3)
 
-#define OUTPUT_CONTRAINTS_6				\
-	OUTPUT_CONTRAINTS_3,				\
-	"r" (arg4), "r" (arg5), "r" (arg6)
+#define OUTPUT_CONTRAINTS_4			\
+	OUTPUT_CONTRAINTS_3,			\
+	"r" (arg4)
 
-#define SYSCALL(number_, nb_args, args...)			\
-	({							\
-		register word_t number asm("r7") = number_;	\
-		register word_t result asm("r0");		\
-		PREPARE_ARGS_##nb_args(args)			\
-			asm volatile (				\
-				"svc #0x00000000	\n\t"	\
-				: "=r" (result)			\
-				: "r" (number),			\
-				OUTPUT_CONTRAINTS_##nb_args	\
-				: "memory");			\
-			result;					\
+#define OUTPUT_CONTRAINTS_6				\
+	OUTPUT_CONTRAINTS_4,				\
+	"r" (arg5), "r" (arg6)
+
+#define SYSCALL(number_, nb_args, args...)				\
+	({								\
+		register word_t number asm("x8") = number_;		\
+		register word_t result asm("x0");			\
+		PREPARE_ARGS_##nb_args(args)				\
+			asm volatile (					\
+				"svc #0x00000000		\n\t"	\
+				: "=r" (result)				\
+				: "r" (number),				\
+				OUTPUT_CONTRAINTS_##nb_args		\
+				: "memory");				\
+			result;						\
 	})
 
-#define OPEN	5
-#define CLOSE	6
-#define MMAP	192
-#define MMAP_OFFSET_SHIFT 12
-#define EXECVE	11
-#define EXIT	1
-#define PRCTL	172
-#define MPROTECT 125
-
+#define OPENAT	56
+#define CLOSE	57
+#define MMAP	222
+#define EXECVE	221
+#define EXIT	93
+#define PRCTL   167
+#define MPROTECT 226

--- a/src/kernel/execve/loader/assembly-x86.h
+++ b/src/kernel/execve/loader/assembly-x86.h
@@ -2,7 +2,7 @@
  *
  * This file is part of PRoot.
  *
- * Copyright (C) 2014 STMicroelectronics
+ * Copyright (C) 2015 STMicroelectronics
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -65,3 +65,4 @@ extern word_t syscall_1(word_t number, word_t arg1);
 #define EXECVE	11
 #define EXIT	1
 #define PRCTL	172
+#define MPROTECT 125

--- a/src/kernel/execve/loader/assembly-x86_64.h
+++ b/src/kernel/execve/loader/assembly-x86_64.h
@@ -2,7 +2,7 @@
  *
  * This file is part of PRoot.
  *
- * Copyright (C) 2014 STMicroelectronics
+ * Copyright (C) 2015 STMicroelectronics
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as

--- a/src/kernel/execve/loader/loader.c
+++ b/src/kernel/execve/loader/loader.c
@@ -2,7 +2,7 @@
  *
  * This file is part of PRoot.
  *
- * Copyright (C) 2014 STMicroelectronics
+ * Copyright (C) 2015 STMicroelectronics
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -39,6 +39,8 @@
 #    include "assembly-arm.h"
 #elif defined(ARCH_X86)
 #    include "assembly-x86.h"
+#elif defined(ARCH_ARM64)
+#    include "assembly-arm64.h"
 #else
 #    error "Unsupported architecture"
 #endif
@@ -132,7 +134,11 @@ void _start(void *cursor)
 			/* Fall through.  */
 
 		case LOAD_ACTION_OPEN:
+#if defined(OPEN)
 			fd = SYSCALL(OPEN, 3, stmt->open.string_address, O_RDONLY, 0);
+#else
+			fd = SYSCALL(OPENAT, 4, AT_FDCWD, stmt->open.string_address, O_RDONLY, 0);
+#endif
 			if (unlikely((int) fd < 0))
 				FATAL();
 

--- a/src/kernel/execve/loader/script.h
+++ b/src/kernel/execve/loader/script.h
@@ -2,7 +2,7 @@
  *
  * This file is part of PRoot.
  *
- * Copyright (C) 2014 STMicroelectronics
+ * Copyright (C) 2015 STMicroelectronics
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as

--- a/src/kernel/groups.rs
+++ b/src/kernel/groups.rs
@@ -93,13 +93,13 @@ pub fn syscall_group_from_sysnum(sysnum: usize) -> SyscallGroup {
         sc::nr::OPEN => SyscallGroup::Open,
 
         // int syscall(int dirfd, const char *pathname, ... , int flags, ...)
-        sc::nr::FCHOWNAT
-        | sc::nr::NEWFSTATAT
-        | sc::nr::UTIMENSAT
-        | sc::nr::NAME_TO_HANDLE_AT
-        | sc::nr::STATX => SyscallGroup::StatAt,
+        sc::nr::FCHOWNAT | sc::nr::UTIMENSAT | sc::nr::NAME_TO_HANDLE_AT | sc::nr::STATX => {
+            SyscallGroup::StatAt
+        }
         #[cfg(any(target_arch = "x86", target_arch = "arm"))]
         sc::nr::FSTATAT64 => SyscallGroup::StatAt,
+        #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+        sc::nr::NEWFSTATAT => SyscallGroup::StatAt,
 
         // int syscall(int dirfd, const char *pathname, ...)
         sc::nr::FCHMODAT | sc::nr::FACCESSAT | sc::nr::MKNODAT => SyscallGroup::ChmodAccessMkNodAt,

--- a/src/kernel/standard/chdir.rs
+++ b/src/kernel/standard/chdir.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use crate::errors::*;
 use crate::filesystem::binding::Side;
 use crate::process::tracee::Tracee;
-use crate::register::{Current, PtraceReader, SysArg, SysArg1, SysResult};
+use crate::register::{Current, PtraceReader, SysArg, SysArg1, SysResult, Word};
 
 pub fn enter(tracee: &mut Tracee) -> Result<()> {
     let sys_num = tracee.regs.get_sys_num(Current);
@@ -49,7 +49,7 @@ pub fn exit(tracee: &mut Tracee) -> Result<()> {
     // This syscall is fully emulated, see method `enter()` above.
     tracee
         .regs
-        .set(SysResult, 0u64, "update return value in chdir::exit()");
+        .set(SysResult, 0 as Word, "update return value in chdir::exit()");
     Ok(())
 }
 

--- a/src/kernel/standard/chmod_access_mknod_at.rs
+++ b/src/kernel/standard/chmod_access_mknod_at.rs
@@ -12,7 +12,9 @@ pub fn enter(tracee: &mut Tracee) -> Result<()> {
 
     let deref_final = match sys_num {
         sc::nr::MKNODAT => false, /* By default, mknodat() will not follow a symbolic link. https://man7.org/linux/man-pages/man2/mknod.2.html */
-        sc::nr::FACCESSAT | sc::nr::FUTIMESAT | sc::nr::FCHMODAT => true,
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "arm"))]
+        sc::nr::FUTIMESAT => true,
+        sc::nr::FACCESSAT | sc::nr::FCHMODAT => true,
         _ => true,
     };
 

--- a/src/kernel/standard/dir_link_attr.rs
+++ b/src/kernel/standard/dir_link_attr.rs
@@ -135,10 +135,10 @@ mod tests {
                     let mut stat = nc::stat_t::default();
                     nc::lstat(linkpath, &mut stat).unwrap();
                     // should be a symlink.
-                    assert_eq!((stat.st_mode & nc::S_IFMT), nc::S_IFLNK);
+                    assert_eq!((stat.st_mode as nc::mode_t & nc::S_IFMT), nc::S_IFLNK);
                     nc::lstat(filepath, &mut stat).unwrap();
                     // should be a symlink.
-                    assert_eq!((stat.st_mode & nc::S_IFMT), nc::S_IFREG);
+                    assert_eq!((stat.st_mode as nc::mode_t & nc::S_IFMT), nc::S_IFREG);
 
                     // test lchown()
 

--- a/src/kernel/standard/dir_link_attr.rs
+++ b/src/kernel/standard/dir_link_attr.rs
@@ -12,6 +12,7 @@ pub fn enter(tracee: &mut Tracee) -> Result<()> {
 
     let deref_final = match sys_num {
         // First, create/delete/rename related system calls cannot follow final component.
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "arm"))]
         sc::nr::UNLINK | sc::nr::RMDIR | sc::nr::MKDIR => false,
         _ => {
             // Second, since there is no flags here, skip check for LOOKUP_FOLLOW.

--- a/src/kernel/standard/getcwd.rs
+++ b/src/kernel/standard/getcwd.rs
@@ -6,8 +6,8 @@ use crate::errors::*;
 
 use crate::filesystem::Translator;
 use crate::process::tracee::Tracee;
-use crate::register::PtraceWriter;
 use crate::register::{Original, SysArg, SysArg1, SysArg2, SysResult};
+use crate::register::{PtraceWriter, Word};
 
 pub fn enter(tracee: &mut Tracee) -> Result<()> {
     tracee
@@ -48,7 +48,7 @@ pub fn exit(tracee: &mut Tracee) -> Result<()> {
     // https://elixir.bootlin.com/linux/v5.10.43/source/fs/d_path.c#L412
     tracee.regs.set(
         SysResult,
-        real_size as u64,
+        real_size as Word,
         "update return value in getcwd::exit()",
     );
     Ok(())

--- a/src/kernel/standard/link_at.rs
+++ b/src/kernel/standard/link_at.rs
@@ -72,7 +72,7 @@ mod tests {
                     nc::linkat(fd, oldlinkname, fd, newlinkname, 0).unwrap();
                     let mut stat = nc::stat_t::default();
                     nc::lstat(newlinkpath, &mut stat).unwrap();
-                    assert_eq!((stat.st_mode & nc::S_IFMT), nc::S_IFLNK);
+                    assert_eq!((stat.st_mode as nc::mode_t & nc::S_IFMT), nc::S_IFLNK);
                     let mut buf = [0_u8; nc::PATH_MAX as usize];
                     let n_read = nc::readlink(newlinkpath, &mut buf).unwrap() as usize;
                     assert_eq!(oldfilepath.as_bytes(), &buf[0..n_read]);
@@ -82,7 +82,10 @@ mod tests {
                     nc::linkat(fd, oldlinkname, fd, newfilename, nc::AT_SYMLINK_FOLLOW).unwrap();
                     let mut new_filestat = nc::stat_t::default();
                     nc::lstat(newfilepath, &mut new_filestat).unwrap();
-                    assert_eq!((new_filestat.st_mode & nc::S_IFMT), nc::S_IFREG);
+                    assert_eq!(
+                        (new_filestat.st_mode as nc::mode_t & nc::S_IFMT),
+                        nc::S_IFREG
+                    );
                     let mut old_filestat = nc::stat_t::default();
                     nc::lstat(oldfilepath, &mut old_filestat).unwrap();
                     assert_eq!(new_filestat.st_ino, old_filestat.st_ino);

--- a/src/kernel/standard/link_rename.rs
+++ b/src/kernel/standard/link_rename.rs
@@ -146,7 +146,7 @@ mod tests {
                     nc::link(original_linkpath, cloned_linkpath).unwrap();
                     let mut stat = nc::stat_t::default();
                     nc::lstat(cloned_linkpath, &mut stat).unwrap();
-                    assert_eq!((stat.st_mode & nc::S_IFMT), nc::S_IFLNK);
+                    assert_eq!((stat.st_mode as nc::mode_t & nc::S_IFMT), nc::S_IFLNK);
                     let mut buf = [0_u8; nc::PATH_MAX as usize];
                     let n_read = nc::readlink(cloned_linkpath, &mut buf).unwrap() as usize;
                     assert_eq!(original_filepath.as_bytes(), &buf[0..n_read]);
@@ -155,7 +155,10 @@ mod tests {
                     nc::link(original_filepath, cloned_filepath).unwrap();
                     let mut cloned_filestat = nc::stat_t::default();
                     nc::lstat(cloned_filepath, &mut cloned_filestat).unwrap();
-                    assert_eq!((cloned_filestat.st_mode & nc::S_IFMT), nc::S_IFREG);
+                    assert_eq!(
+                        (cloned_filestat.st_mode as nc::mode_t & nc::S_IFMT),
+                        nc::S_IFREG
+                    );
 
                     let mut original_filestat = nc::stat_t::default();
                     nc::lstat(original_filepath, &mut original_filestat).unwrap();
@@ -168,7 +171,7 @@ mod tests {
                     // This file does not exist because it has been renamed.
                     assert_eq!(nc::lstat(cloned_filepath, &mut stat), Err(nc::ENOENT));
                     nc::lstat(renamed_filepath, &mut stat).unwrap();
-                    assert_eq!((stat.st_mode & nc::S_IFMT), nc::S_IFREG);
+                    assert_eq!((stat.st_mode as nc::mode_t & nc::S_IFMT), nc::S_IFREG);
 
                     // test renameat()
                     nc::renameat(fd, renamed_filename, fd, rerenamed_filename).unwrap();
@@ -176,7 +179,7 @@ mod tests {
                     // This file does not exist because it has been renamed.
                     assert_eq!(nc::lstat(renamed_filepath, &mut stat), Err(nc::ENOENT));
                     nc::lstat(rerenamed_filepath, &mut stat).unwrap();
-                    assert_eq!((stat.st_mode & nc::S_IFMT), nc::S_IFREG);
+                    assert_eq!((stat.st_mode as nc::mode_t & nc::S_IFMT), nc::S_IFREG);
                 });
 
                 let _ = std::fs::remove_file(original_filepath);

--- a/src/kernel/standard/open.rs
+++ b/src/kernel/standard/open.rs
@@ -66,7 +66,7 @@ mod tests {
                     let file_fd = nc::open(linkpath, nc::O_RDONLY | nc::O_CREAT, 0o755).unwrap();
                     let mut stat = nc::stat_t::default();
                     nc::fstat(file_fd, &mut stat).unwrap();
-                    assert_eq!((stat.st_mode & nc::S_IFMT), nc::S_IFREG);
+                    assert_eq!((stat.st_mode as nc::mode_t & nc::S_IFMT), nc::S_IFREG);
                     nc::unlink(filepath).unwrap();
 
                     // Test open(filepath) with `O_CREAT` and `O_EXCL`, and this will create a
@@ -75,21 +75,21 @@ mod tests {
                         nc::open(filepath, nc::O_RDONLY | nc::O_CREAT | nc::O_EXCL, 0o755).unwrap();
                     let mut stat = nc::stat_t::default();
                     nc::fstat(file_fd, &mut stat).unwrap();
-                    assert_eq!((stat.st_mode & nc::S_IFMT), nc::S_IFREG);
+                    assert_eq!((stat.st_mode as nc::mode_t & nc::S_IFMT), nc::S_IFREG);
                     nc::close(file_fd).unwrap();
 
                     // test open() with `OFlag::O_NOFOLLOW`;
                     let file_fd = nc::open(linkpath, nc::O_NOFOLLOW | nc::O_PATH, 0).unwrap();
                     let mut stat = nc::stat_t::default();
                     nc::fstat(file_fd, &mut stat).unwrap();
-                    assert_eq!((stat.st_mode & nc::S_IFMT), nc::S_IFLNK);
+                    assert_eq!((stat.st_mode as nc::mode_t & nc::S_IFMT), nc::S_IFLNK);
                     nc::close(file_fd).unwrap();
 
                     // test open() in normal case;
                     let file_fd = nc::open(linkpath, 0, 0).unwrap();
                     let mut stat = nc::stat_t::default();
                     nc::fstat(file_fd, &mut stat).unwrap();
-                    assert_eq!((stat.st_mode & nc::S_IFMT), nc::S_IFREG);
+                    assert_eq!((stat.st_mode as nc::mode_t & nc::S_IFMT), nc::S_IFREG);
                     nc::close(file_fd).unwrap();
                 });
                 let _ = std::fs::remove_file(linkpath);

--- a/src/kernel/standard/open_at.rs
+++ b/src/kernel/standard/open_at.rs
@@ -60,21 +60,21 @@ mod tests {
                             .unwrap();
                     let mut stat = nc::stat_t::default();
                     nc::fstat(file_fd, &mut stat).unwrap();
-                    assert_eq!((stat.st_mode & nc::S_IFMT), nc::S_IFREG);
+                    assert_eq!((stat.st_mode as nc::mode_t & nc::S_IFMT), nc::S_IFREG);
                     nc::close(file_fd).unwrap();
 
                     // test openat() with `OFlag::O_NOFOLLOW`;
                     let file_fd = nc::openat(fd, linkname, nc::O_NOFOLLOW | nc::O_PATH, 0).unwrap();
                     let mut stat = nc::stat_t::default();
                     nc::fstat(file_fd, &mut stat).unwrap();
-                    assert_eq!((stat.st_mode & nc::S_IFMT), nc::S_IFLNK);
+                    assert_eq!((stat.st_mode as nc::mode_t & nc::S_IFMT), nc::S_IFLNK);
                     nc::close(file_fd).unwrap();
 
                     // test openat() in normal case;
                     let file_fd = nc::openat(fd, linkname, 0, 0).unwrap();
                     let mut stat = nc::stat_t::default();
                     nc::fstat(file_fd, &mut stat).unwrap();
-                    assert_eq!((stat.st_mode & nc::S_IFMT), nc::S_IFREG);
+                    assert_eq!((stat.st_mode as nc::mode_t & nc::S_IFMT), nc::S_IFREG);
                     nc::close(file_fd).unwrap();
                 });
                 std::fs::remove_file(linkpath).unwrap();

--- a/src/kernel/standard/open_at.rs
+++ b/src/kernel/standard/open_at.rs
@@ -55,16 +55,22 @@ mod tests {
 
                     // test openat() with `O_CREAT` and `O_EXCL`
                     // this will create a regular file at `filepath`
-                    let file_fd =
-                        nc::openat(fd, filename, nc::O_RDONLY | nc::O_CREAT | nc::O_EXCL, 0o755)
-                            .unwrap();
+                    let file_fd = nc::openat(
+                        fd,
+                        filename,
+                        (OFlag::O_RDONLY | OFlag::O_CREAT | OFlag::O_EXCL).bits(),
+                        0o755,
+                    )
+                    .unwrap();
                     let mut stat = nc::stat_t::default();
                     nc::fstat(file_fd, &mut stat).unwrap();
                     assert_eq!((stat.st_mode as nc::mode_t & nc::S_IFMT), nc::S_IFREG);
                     nc::close(file_fd).unwrap();
 
                     // test openat() with `OFlag::O_NOFOLLOW`;
-                    let file_fd = nc::openat(fd, linkname, nc::O_NOFOLLOW | nc::O_PATH, 0).unwrap();
+                    let file_fd =
+                        nc::openat(fd, linkname, (OFlag::O_NOFOLLOW | OFlag::O_PATH).bits(), 0)
+                            .unwrap();
                     let mut stat = nc::stat_t::default();
                     nc::fstat(file_fd, &mut stat).unwrap();
                     assert_eq!((stat.st_mode as nc::mode_t & nc::S_IFMT), nc::S_IFLNK);

--- a/src/kernel/standard/standard_syscall.rs
+++ b/src/kernel/standard/standard_syscall.rs
@@ -51,9 +51,9 @@ mod tests {
                     nc::stat(linkpath, &mut stat).unwrap();
                     // should be a regular file, since symbol link file will be dereference
                     // automatically.
-                    assert_eq!((stat.st_mode & nc::S_IFMT), nc::S_IFREG);
+                    assert_eq!((stat.st_mode as nc::mode_t & nc::S_IFMT), nc::S_IFREG);
                     nc::stat(filepath, &mut stat).unwrap();
-                    assert_eq!((stat.st_mode & nc::S_IFMT), nc::S_IFREG);
+                    assert_eq!((stat.st_mode as nc::mode_t & nc::S_IFMT), nc::S_IFREG);
                 });
                 std::fs::remove_file(filepath).unwrap();
                 std::fs::remove_file(linkpath).unwrap();

--- a/src/kernel/standard/stat_at.rs
+++ b/src/kernel/standard/stat_at.rs
@@ -122,13 +122,16 @@ mod tests {
                     assert_eq!((statx.stx_mode as u32 & nc::S_IFMT), nc::S_IFLNK);
 
                     // test newfstatat()
-                    let mut stat = nc::stat_t::default();
-                    nc::newfstatat(fd, linkname, &mut stat, 0).unwrap();
-                    // should be a regular file, since AT_SYMLINK_NOFOLLOW is not set.
-                    assert_eq!((stat.st_mode & nc::S_IFMT), nc::S_IFREG);
-                    nc::newfstatat(fd, linkname, &mut stat, nc::AT_SYMLINK_NOFOLLOW).unwrap();
-                    // should be a symlink, since AT_SYMLINK_NOFOLLOW is set.
-                    assert_eq!((stat.st_mode & nc::S_IFMT), nc::S_IFLNK);
+                    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+                    {
+                        let mut stat = nc::stat_t::default();
+                        nc::newfstatat(fd, linkname, &mut stat, 0).unwrap();
+                        // should be a regular file, since AT_SYMLINK_NOFOLLOW is not set.
+                        assert_eq!((stat.st_mode & nc::S_IFMT), nc::S_IFREG);
+                        nc::newfstatat(fd, linkname, &mut stat, nc::AT_SYMLINK_NOFOLLOW).unwrap();
+                        // should be a symlink, since AT_SYMLINK_NOFOLLOW is set.
+                        assert_eq!((stat.st_mode & nc::S_IFMT), nc::S_IFLNK);
+                    }
 
                     // test utimensat()
 

--- a/src/kernel/standard/sym_link.rs
+++ b/src/kernel/standard/sym_link.rs
@@ -48,14 +48,14 @@ mod tests {
                     let mut stat = nc::stat_t::default();
                     // both `linkpath_1` and `linkpath_2` should be symlink
                     nc::lstat(linkpath_1, &mut stat).unwrap();
-                    assert_eq!((stat.st_mode & nc::S_IFMT), nc::S_IFLNK);
+                    assert_eq!((stat.st_mode as nc::mode_t & nc::S_IFMT), nc::S_IFLNK);
                     nc::lstat(linkpath_2, &mut stat).unwrap();
-                    assert_eq!((stat.st_mode & nc::S_IFMT), nc::S_IFLNK);
+                    assert_eq!((stat.st_mode as nc::mode_t & nc::S_IFMT), nc::S_IFLNK);
                     // both `linkpath_1` and `linkpath_2` should point to a regular file
                     nc::stat(linkpath_1, &mut stat).unwrap();
-                    assert_eq!((stat.st_mode & nc::S_IFMT), nc::S_IFREG);
+                    assert_eq!((stat.st_mode as nc::mode_t & nc::S_IFMT), nc::S_IFREG);
                     nc::stat(linkpath_2, &mut stat).unwrap();
-                    assert_eq!((stat.st_mode & nc::S_IFMT), nc::S_IFREG);
+                    assert_eq!((stat.st_mode as nc::mode_t & nc::S_IFMT), nc::S_IFREG);
                 });
                 std::fs::remove_file(filepath).unwrap();
                 std::fs::remove_file(linkpath_1).unwrap();

--- a/src/kernel/standard/sym_link_at.rs
+++ b/src/kernel/standard/sym_link_at.rs
@@ -56,14 +56,14 @@ mod tests {
                     let mut stat = nc::stat_t::default();
                     // both `linkpath_1` and `linkpath_2` should be symlink
                     nc::lstat(linkpath_1, &mut stat).unwrap();
-                    assert_eq!((stat.st_mode & nc::S_IFMT), nc::S_IFLNK);
+                    assert_eq!((stat.st_mode as nc::mode_t & nc::S_IFMT), nc::S_IFLNK);
                     nc::lstat(linkpath_2, &mut stat).unwrap();
-                    assert_eq!((stat.st_mode & nc::S_IFMT), nc::S_IFLNK);
+                    assert_eq!((stat.st_mode as nc::mode_t & nc::S_IFMT), nc::S_IFLNK);
                     // both `linkpath_1` and `linkpath_2` should point to a regular file
                     nc::stat(linkpath_1, &mut stat).unwrap();
-                    assert_eq!((stat.st_mode & nc::S_IFMT), nc::S_IFREG);
+                    assert_eq!((stat.st_mode as nc::mode_t & nc::S_IFMT), nc::S_IFREG);
                     nc::stat(linkpath_2, &mut stat).unwrap();
-                    assert_eq!((stat.st_mode & nc::S_IFMT), nc::S_IFREG);
+                    assert_eq!((stat.st_mode as nc::mode_t & nc::S_IFMT), nc::S_IFREG);
                 });
                 std::fs::remove_file(filepath).unwrap();
                 std::fs::remove_file(linkpath_1).unwrap();

--- a/src/kernel/syscall.rs
+++ b/src/kernel/syscall.rs
@@ -9,362 +9,835 @@ use crate::register::{
 };
 
 lazy_static! {
+    // Generated from https://chromium.googlesource.com/chromiumos/docs/+/master/constants/syscalls.md#cross_arch-numbers
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     static ref SYSNUM_TO_SYSCALL_NAME: HashMap<usize, &'static str> = [
+        #[cfg(any(target_arch = "arm"))]
+        (sc::nr::ARM_BREAKPOINT, "ARM_breakpoint"),
+        #[cfg(any(target_arch = "arm"))]
+        (sc::nr::ARM_CACHEFLUSH, "ARM_cacheflush"),
+        #[cfg(any(target_arch = "arm"))]
+        (sc::nr::ARM_SET_TLS, "ARM_set_tls"),
+        #[cfg(any(target_arch = "arm"))]
+        (sc::nr::ARM_USR26, "ARM_usr26"),
+        #[cfg(any(target_arch = "arm"))]
+        (sc::nr::ARM_USR32, "ARM_usr32"),
+        #[cfg(any(target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::_LLSEEK, "_llseek"),
+        #[cfg(any(target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::_NEWSELECT, "_newselect"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "x86"))]
         (sc::nr::_SYSCTL, "_sysctl"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64"))]
         (sc::nr::ACCEPT, "accept"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::ACCEPT4, "accept4"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "x86"))]
         (sc::nr::ACCESS, "access"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::ACCT, "acct"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::ADD_KEY, "add_key"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::ADJTIMEX, "adjtimex"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
         (sc::nr::AFS_SYSCALL, "afs_syscall"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
         (sc::nr::ALARM, "alarm"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
         (sc::nr::ARCH_PRCTL, "arch_prctl"),
+        #[cfg(any(target_arch = "arm"))]
+        (sc::nr::ARM_FADVISE64_64, "arm_fadvise64_64"),
+        #[cfg(any(target_arch = "arm"))]
+        (sc::nr::ARM_SYNC_FILE_RANGE, "arm_sync_file_range"),
+        #[cfg(any(target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::BDFLUSH, "bdflush"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::BIND, "bind"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::BPF, "bpf"),
+        #[cfg(any(target_arch = "x86"))]
+        (sc::nr::BREAK, "break"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::BRK, "brk"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::CAPGET, "capget"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::CAPSET, "capset"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::CHDIR, "chdir"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "x86"))]
         (sc::nr::CHMOD, "chmod"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "x86"))]
         (sc::nr::CHOWN, "chown"),
+        #[cfg(any(target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::CHOWN32, "chown32"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::CHROOT, "chroot"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::CLOCK_ADJTIME, "clock_adjtime"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::CLOCK_GETRES, "clock_getres"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::CLOCK_GETTIME, "clock_gettime"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::CLOCK_NANOSLEEP, "clock_nanosleep"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::CLOCK_SETTIME, "clock_settime"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::CLONE, "clone"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::CLOSE, "close"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::CONNECT, "connect"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::COPY_FILE_RANGE, "copy_file_range"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "x86"))]
         (sc::nr::CREAT, "creat"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
         (sc::nr::CREATE_MODULE, "create_module"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::DELETE_MODULE, "delete_module"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::DUP, "dup"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "x86"))]
         (sc::nr::DUP2, "dup2"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::DUP3, "dup3"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "x86"))]
         (sc::nr::EPOLL_CREATE, "epoll_create"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::EPOLL_CREATE1, "epoll_create1"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::EPOLL_CTL, "epoll_ctl"),
+        #[cfg(any(target_arch = "x86_64"))]
         (sc::nr::EPOLL_CTL_OLD, "epoll_ctl_old"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::EPOLL_PWAIT, "epoll_pwait"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "x86"))]
         (sc::nr::EPOLL_WAIT, "epoll_wait"),
+        #[cfg(any(target_arch = "x86_64"))]
         (sc::nr::EPOLL_WAIT_OLD, "epoll_wait_old"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "x86"))]
         (sc::nr::EVENTFD, "eventfd"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::EVENTFD2, "eventfd2"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::EXECVE, "execve"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::EXECVEAT, "execveat"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::EXIT, "exit"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::EXIT_GROUP, "exit_group"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::FACCESSAT, "faccessat"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::FADVISE64, "fadvise64"),
+        #[cfg(any(target_arch = "x86"))]
+        (sc::nr::FADVISE64_64, "fadvise64_64"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::FALLOCATE, "fallocate"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::FANOTIFY_INIT, "fanotify_init"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::FANOTIFY_MARK, "fanotify_mark"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::FCHDIR, "fchdir"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::FCHMOD, "fchmod"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::FCHMODAT, "fchmodat"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::FCHOWN, "fchown"),
+        #[cfg(any(target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::FCHOWN32, "fchown32"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::FCHOWNAT, "fchownat"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::FCNTL, "fcntl"),
+        #[cfg(any(target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::FCNTL64, "fcntl64"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::FDATASYNC, "fdatasync"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::FGETXATTR, "fgetxattr"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::FINIT_MODULE, "finit_module"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::FLISTXATTR, "flistxattr"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::FLOCK, "flock"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "x86"))]
         (sc::nr::FORK, "fork"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::FREMOVEXATTR, "fremovexattr"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::FSETXATTR, "fsetxattr"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::FSTAT, "fstat"),
+        #[cfg(any(target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::FSTAT64, "fstat64"),
+        #[cfg(any(target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::FSTATAT64, "fstatat64"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::FSTATFS, "fstatfs"),
+        #[cfg(any(target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::FSTATFS64, "fstatfs64"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::FSYNC, "fsync"),
+        #[cfg(any(target_arch = "x86"))]
+        (sc::nr::FTIME, "ftime"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::FTRUNCATE, "ftruncate"),
+        #[cfg(any(target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::FTRUNCATE64, "ftruncate64"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::FUTEX, "futex"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "x86"))]
         (sc::nr::FUTIMESAT, "futimesat"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
         (sc::nr::GET_KERNEL_SYMS, "get_kernel_syms"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::GET_MEMPOLICY, "get_mempolicy"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::GET_ROBUST_LIST, "get_robust_list"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
         (sc::nr::GET_THREAD_AREA, "get_thread_area"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::GETCPU, "getcpu"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::GETCWD, "getcwd"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "x86"))]
         (sc::nr::GETDENTS, "getdents"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::GETDENTS64, "getdents64"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::GETEGID, "getegid"),
+        #[cfg(any(target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::GETEGID32, "getegid32"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::GETEUID, "geteuid"),
+        #[cfg(any(target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::GETEUID32, "geteuid32"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::GETGID, "getgid"),
+        #[cfg(any(target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::GETGID32, "getgid32"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::GETGROUPS, "getgroups"),
+        #[cfg(any(target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::GETGROUPS32, "getgroups32"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::GETITIMER, "getitimer"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::GETPEERNAME, "getpeername"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::GETPGID, "getpgid"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "x86"))]
         (sc::nr::GETPGRP, "getpgrp"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::GETPID, "getpid"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
         (sc::nr::GETPMSG, "getpmsg"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::GETPPID, "getppid"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::GETPRIORITY, "getpriority"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::GETRANDOM, "getrandom"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::GETRESGID, "getresgid"),
+        #[cfg(any(target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::GETRESGID32, "getresgid32"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::GETRESUID, "getresuid"),
+        #[cfg(any(target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::GETRESUID32, "getresuid32"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::GETRLIMIT, "getrlimit"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::GETRUSAGE, "getrusage"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::GETSID, "getsid"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::GETSOCKNAME, "getsockname"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::GETSOCKOPT, "getsockopt"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::GETTID, "gettid"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::GETTIMEOFDAY, "gettimeofday"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::GETUID, "getuid"),
+        #[cfg(any(target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::GETUID32, "getuid32"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::GETXATTR, "getxattr"),
+        #[cfg(any(target_arch = "x86"))]
+        (sc::nr::GTTY, "gtty"),
+        #[cfg(any(target_arch = "x86"))]
+        (sc::nr::IDLE, "idle"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::INIT_MODULE, "init_module"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::INOTIFY_ADD_WATCH, "inotify_add_watch"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "x86"))]
         (sc::nr::INOTIFY_INIT, "inotify_init"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::INOTIFY_INIT1, "inotify_init1"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::INOTIFY_RM_WATCH, "inotify_rm_watch"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::IO_CANCEL, "io_cancel"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::IO_DESTROY, "io_destroy"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::IO_GETEVENTS, "io_getevents"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::IO_SETUP, "io_setup"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::IO_SUBMIT, "io_submit"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::IOCTL, "ioctl"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
         (sc::nr::IOPERM, "ioperm"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
         (sc::nr::IOPL, "iopl"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::IOPRIO_GET, "ioprio_get"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::IOPRIO_SET, "ioprio_set"),
+        #[cfg(any(target_arch = "x86"))]
+        (sc::nr::IPC, "ipc"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::KCMP, "kcmp"),
+        #[cfg(any(target_arch = "x86_64"))]
         (sc::nr::KEXEC_FILE_LOAD, "kexec_file_load"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::KEXEC_LOAD, "kexec_load"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::KEYCTL, "keyctl"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::KILL, "kill"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "x86"))]
         (sc::nr::LCHOWN, "lchown"),
+        #[cfg(any(target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::LCHOWN32, "lchown32"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::LGETXATTR, "lgetxattr"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "x86"))]
         (sc::nr::LINK, "link"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::LINKAT, "linkat"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::LISTEN, "listen"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::LISTXATTR, "listxattr"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::LLISTXATTR, "llistxattr"),
+        #[cfg(any(target_arch = "x86"))]
+        (sc::nr::LOCK, "lock"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::LOOKUP_DCOOKIE, "lookup_dcookie"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::LREMOVEXATTR, "lremovexattr"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::LSEEK, "lseek"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::LSETXATTR, "lsetxattr"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "x86"))]
         (sc::nr::LSTAT, "lstat"),
+        #[cfg(any(target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::LSTAT64, "lstat64"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::MADVISE, "madvise"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::MBIND, "mbind"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::MEMBARRIER, "membarrier"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::MEMFD_CREATE, "memfd_create"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::MIGRATE_PAGES, "migrate_pages"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::MINCORE, "mincore"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "x86"))]
         (sc::nr::MKDIR, "mkdir"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::MKDIRAT, "mkdirat"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "x86"))]
         (sc::nr::MKNOD, "mknod"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::MKNODAT, "mknodat"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::MLOCK, "mlock"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::MLOCK2, "mlock2"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::MLOCKALL, "mlockall"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::MMAP, "mmap"),
+        #[cfg(any(target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::MMAP2, "mmap2"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
         (sc::nr::MODIFY_LDT, "modify_ldt"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::MOUNT, "mount"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::MOVE_PAGES, "move_pages"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::MPROTECT, "mprotect"),
+        #[cfg(any(target_arch = "x86"))]
+        (sc::nr::MPX, "mpx"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::MQ_GETSETATTR, "mq_getsetattr"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::MQ_NOTIFY, "mq_notify"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::MQ_OPEN, "mq_open"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::MQ_TIMEDRECEIVE, "mq_timedreceive"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::MQ_TIMEDSEND, "mq_timedsend"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::MQ_UNLINK, "mq_unlink"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::MREMAP, "mremap"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64"))]
         (sc::nr::MSGCTL, "msgctl"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64"))]
         (sc::nr::MSGGET, "msgget"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64"))]
         (sc::nr::MSGRCV, "msgrcv"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64"))]
         (sc::nr::MSGSND, "msgsnd"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::MSYNC, "msync"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::MUNLOCK, "munlock"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::MUNLOCKALL, "munlockall"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::MUNMAP, "munmap"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::NAME_TO_HANDLE_AT, "name_to_handle_at"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::NANOSLEEP, "nanosleep"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
         (sc::nr::NEWFSTATAT, "newfstatat"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::NFSSERVCTL, "nfsservctl"),
-        (sc::nr::OPEN, "open"),
-        (sc::nr::OPEN_BY_HANDLE_AT, "open_by_handle_at"),
-        (sc::nr::OPENAT, "openat"),
-        (sc::nr::PAUSE, "pause"),
-        (sc::nr::PERF_EVENT_OPEN, "perf_event_open"),
-        (sc::nr::PERSONALITY, "personality"),
-        (sc::nr::PIPE, "pipe"),
-        (sc::nr::PIPE2, "pipe2"),
-        (sc::nr::PIVOT_ROOT, "pivot_root"),
-        (sc::nr::PKEY_ALLOC, "pkey_alloc"),
-        (sc::nr::PKEY_FREE, "pkey_free"),
-        (sc::nr::PKEY_MPROTECT, "pkey_mprotect"),
-        (sc::nr::POLL, "poll"),
-        (sc::nr::PPOLL, "ppoll"),
-        (sc::nr::PRCTL, "prctl"),
-        (sc::nr::PREAD64, "pread64"),
-        (sc::nr::PREADV, "preadv"),
-        (sc::nr::PREADV2, "preadv2"),
-        (sc::nr::PRLIMIT64, "prlimit64"),
-        (sc::nr::PROCESS_VM_READV, "process_vm_readv"),
-        (sc::nr::PROCESS_VM_WRITEV, "process_vm_writev"),
-        (sc::nr::PSELECT6, "pselect6"),
-        (sc::nr::PTRACE, "ptrace"),
-        (sc::nr::PUTPMSG, "putpmsg"),
-        (sc::nr::PWRITE64, "pwrite64"),
-        (sc::nr::PWRITEV, "pwritev"),
-        (sc::nr::PWRITEV2, "pwritev2"),
-        (sc::nr::QUERY_MODULE, "query_module"),
-        (sc::nr::QUOTACTL, "quotactl"),
-        (sc::nr::READ, "read"),
-        (sc::nr::READAHEAD, "readahead"),
-        (sc::nr::READLINK, "readlink"),
-        (sc::nr::READLINKAT, "readlinkat"),
-        (sc::nr::READV, "readv"),
-        (sc::nr::REBOOT, "reboot"),
-        (sc::nr::RECVFROM, "recvfrom"),
-        (sc::nr::RECVMMSG, "recvmmsg"),
-        (sc::nr::RECVMSG, "recvmsg"),
-        (sc::nr::REMAP_FILE_PAGES, "remap_file_pages"),
-        (sc::nr::REMOVEXATTR, "removexattr"),
-        (sc::nr::RENAME, "rename"),
-        (sc::nr::RENAMEAT, "renameat"),
-        (sc::nr::RENAMEAT2, "renameat2"),
-        (sc::nr::REQUEST_KEY, "request_key"),
-        (sc::nr::RESTART_SYSCALL, "restart_syscall"),
-        (sc::nr::RMDIR, "rmdir"),
-        (sc::nr::RT_SIGACTION, "rt_sigaction"),
-        (sc::nr::RT_SIGPENDING, "rt_sigpending"),
-        (sc::nr::RT_SIGPROCMASK, "rt_sigprocmask"),
-        (sc::nr::RT_SIGQUEUEINFO, "rt_sigqueueinfo"),
-        (sc::nr::RT_SIGRETURN, "rt_sigreturn"),
-        (sc::nr::RT_SIGSUSPEND, "rt_sigsuspend"),
-        (sc::nr::RT_SIGTIMEDWAIT, "rt_sigtimedwait"),
-        (sc::nr::RT_TGSIGQUEUEINFO, "rt_tgsigqueueinfo"),
-        (sc::nr::SCHED_GET_PRIORITY_MAX, "sched_get_priority_max"),
-        (sc::nr::SCHED_GET_PRIORITY_MIN, "sched_get_priority_min"),
-        (sc::nr::SCHED_GETAFFINITY, "sched_getaffinity"),
-        (sc::nr::SCHED_GETATTR, "sched_getattr"),
-        (sc::nr::SCHED_GETPARAM, "sched_getparam"),
-        (sc::nr::SCHED_GETSCHEDULER, "sched_getscheduler"),
-        (sc::nr::SCHED_RR_GET_INTERVAL, "sched_rr_get_interval"),
-        (sc::nr::SCHED_SETAFFINITY, "sched_setaffinity"),
-        (sc::nr::SCHED_SETATTR, "sched_setattr"),
-        (sc::nr::SCHED_SETPARAM, "sched_setparam"),
-        (sc::nr::SCHED_SETSCHEDULER, "sched_setscheduler"),
-        (sc::nr::SCHED_YIELD, "sched_yield"),
-        (sc::nr::SECCOMP, "seccomp"),
-        (sc::nr::SECURITY, "security"),
-        (sc::nr::SELECT, "select"),
-        (sc::nr::SEMCTL, "semctl"),
-        (sc::nr::SEMGET, "semget"),
-        (sc::nr::SEMOP, "semop"),
-        (sc::nr::SEMTIMEDOP, "semtimedop"),
-        (sc::nr::SENDFILE, "sendfile"),
-        (sc::nr::SENDMMSG, "sendmmsg"),
-        (sc::nr::SENDMSG, "sendmsg"),
-        (sc::nr::SENDTO, "sendto"),
-        (sc::nr::SET_MEMPOLICY, "set_mempolicy"),
-        (sc::nr::SET_ROBUST_LIST, "set_robust_list"),
-        (sc::nr::SET_THREAD_AREA, "set_thread_area"),
-        (sc::nr::SET_TID_ADDRESS, "set_tid_address"),
-        (sc::nr::SETDOMAINNAME, "setdomainname"),
-        (sc::nr::SETFSGID, "setfsgid"),
-        (sc::nr::SETFSUID, "setfsuid"),
-        (sc::nr::SETGID, "setgid"),
-        (sc::nr::SETGROUPS, "setgroups"),
-        (sc::nr::SETHOSTNAME, "sethostname"),
-        (sc::nr::SETITIMER, "setitimer"),
-        (sc::nr::SETNS, "setns"),
-        (sc::nr::SETPGID, "setpgid"),
-        (sc::nr::SETPRIORITY, "setpriority"),
-        (sc::nr::SETREGID, "setregid"),
-        (sc::nr::SETRESGID, "setresgid"),
-        (sc::nr::SETRESUID, "setresuid"),
-        (sc::nr::SETREUID, "setreuid"),
-        (sc::nr::SETRLIMIT, "setrlimit"),
-        (sc::nr::SETSID, "setsid"),
-        (sc::nr::SETSOCKOPT, "setsockopt"),
-        (sc::nr::SETTIMEOFDAY, "settimeofday"),
-        (sc::nr::SETUID, "setuid"),
-        (sc::nr::SETXATTR, "setxattr"),
-        (sc::nr::SHMAT, "shmat"),
-        (sc::nr::SHMCTL, "shmctl"),
-        (sc::nr::SHMDT, "shmdt"),
-        (sc::nr::SHMGET, "shmget"),
-        (sc::nr::SHUTDOWN, "shutdown"),
-        (sc::nr::SIGALTSTACK, "sigaltstack"),
-        (sc::nr::SIGNALFD, "signalfd"),
-        (sc::nr::SIGNALFD4, "signalfd4"),
-        (sc::nr::SOCKET, "socket"),
-        (sc::nr::SOCKETPAIR, "socketpair"),
-        (sc::nr::SPLICE, "splice"),
-        (sc::nr::STAT, "stat"),
-        (sc::nr::STATFS, "statfs"),
-        (sc::nr::STATX, "statx"),
-        (sc::nr::SWAPOFF, "swapoff"),
-        (sc::nr::SWAPON, "swapon"),
-        (sc::nr::SYMLINK, "symlink"),
-        (sc::nr::SYMLINKAT, "symlinkat"),
-        (sc::nr::SYNC, "sync"),
-        (sc::nr::SYNC_FILE_RANGE, "sync_file_range"),
-        (sc::nr::SYNCFS, "syncfs"),
-        (sc::nr::SYSFS, "sysfs"),
-        (sc::nr::SYSINFO, "sysinfo"),
-        (sc::nr::SYSLOG, "syslog"),
-        (sc::nr::TEE, "tee"),
-        (sc::nr::TGKILL, "tgkill"),
-        (sc::nr::TIME, "time"),
-        (sc::nr::TIMER_CREATE, "timer_create"),
-        (sc::nr::TIMER_DELETE, "timer_delete"),
-        (sc::nr::TIMER_GETOVERRUN, "timer_getoverrun"),
-        (sc::nr::TIMER_GETTIME, "timer_gettime"),
-        (sc::nr::TIMER_SETTIME, "timer_settime"),
-        (sc::nr::TIMERFD_CREATE, "timerfd_create"),
-        (sc::nr::TIMERFD_GETTIME, "timerfd_gettime"),
-        (sc::nr::TIMERFD_SETTIME, "timerfd_settime"),
-        (sc::nr::TIMES, "times"),
-        (sc::nr::TKILL, "tkill"),
-        (sc::nr::TRUNCATE, "truncate"),
-        (sc::nr::TUXCALL, "tuxcall"),
-        (sc::nr::UMASK, "umask"),
-        (sc::nr::UMOUNT2, "umount2"),
-        (sc::nr::UNAME, "uname"),
-        (sc::nr::UNLINK, "unlink"),
-        (sc::nr::UNLINKAT, "unlinkat"),
-        (sc::nr::UNSHARE, "unshare"),
-        (sc::nr::USELIB, "uselib"),
-        (sc::nr::USERFAULTFD, "userfaultfd"),
-        (sc::nr::USTAT, "ustat"),
-        (sc::nr::UTIME, "utime"),
-        (sc::nr::UTIMENSAT, "utimensat"),
-        (sc::nr::UTIMES, "utimes"),
-        (sc::nr::VFORK, "vfork"),
-        (sc::nr::VHANGUP, "vhangup"),
-        (sc::nr::VMSPLICE, "vmsplice"),
-        (sc::nr::VSERVER, "vserver"),
-        (sc::nr::WAIT4, "wait4"),
-        (sc::nr::WAITID, "waitid"),
-        (sc::nr::WRITE, "write"),
-        (sc::nr::WRITEV, "writev"),
+        #[cfg(any(target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::NICE, "nice"),
         #[cfg(any(target_arch = "x86"))]
-        (sc::nr::WAITPID, "waitpid"),
+        (sc::nr::OLDFSTAT, "oldfstat"),
         #[cfg(any(target_arch = "x86"))]
-        (sc::nr::SOCKETCALL, "socketcall"),
+        (sc::nr::OLDLSTAT, "oldlstat"),
+        #[cfg(any(target_arch = "x86"))]
+        (sc::nr::OLDOLDUNAME, "oldolduname"),
         #[cfg(any(target_arch = "x86"))]
         (sc::nr::OLDSTAT, "oldstat"),
         #[cfg(any(target_arch = "x86"))]
-        (sc::nr::UMOUNT, "umount"),
+        (sc::nr::OLDUNAME, "olduname"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::OPEN, "open"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::OPEN_BY_HANDLE_AT, "open_by_handle_at"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::OPENAT, "openat"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::PAUSE, "pause"),
+        #[cfg(any(target_arch = "arm"))]
+        (sc::nr::PCICONFIG_IOBASE, "pciconfig_iobase"),
+        #[cfg(any(target_arch = "arm"))]
+        (sc::nr::PCICONFIG_READ, "pciconfig_read"),
+        #[cfg(any(target_arch = "arm"))]
+        (sc::nr::PCICONFIG_WRITE, "pciconfig_write"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::PERF_EVENT_OPEN, "perf_event_open"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::PERSONALITY, "personality"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::PIPE, "pipe"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::PIPE2, "pipe2"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::PIVOT_ROOT, "pivot_root"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::PKEY_ALLOC, "pkey_alloc"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::PKEY_FREE, "pkey_free"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::PKEY_MPROTECT, "pkey_mprotect"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::POLL, "poll"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::PPOLL, "ppoll"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::PRCTL, "prctl"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::PREAD64, "pread64"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::PREADV, "preadv"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::PREADV2, "preadv2"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::PRLIMIT64, "prlimit64"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::PROCESS_VM_READV, "process_vm_readv"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::PROCESS_VM_WRITEV, "process_vm_writev"),
         #[cfg(any(target_arch = "x86"))]
-        (sc::nr::OLDLSTAT, "oldlstat"),
-        #[cfg(any(target_arch = "x86", target_arch = "arm"))]
-        (sc::nr::CHOWN32, "chown32"),
-        #[cfg(any(target_arch = "x86", target_arch = "arm"))]
+        (sc::nr::PROF, "prof"),
+        #[cfg(any(target_arch = "x86"))]
+        (sc::nr::PROFIL, "profil"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::PSELECT6, "pselect6"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::PTRACE, "ptrace"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+        (sc::nr::PUTPMSG, "putpmsg"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::PWRITE64, "pwrite64"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::PWRITEV, "pwritev"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::PWRITEV2, "pwritev2"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+        (sc::nr::QUERY_MODULE, "query_module"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::QUOTACTL, "quotactl"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::READ, "read"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::READAHEAD, "readahead"),
+        #[cfg(any(target_arch = "x86"))]
+        (sc::nr::READDIR, "readdir"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::READLINK, "readlink"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::READLINKAT, "readlinkat"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::READV, "readv"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::REBOOT, "reboot"),
+        #[cfg(any(target_arch = "arm"))]
+        (sc::nr::RECV, "recv"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::RECVFROM, "recvfrom"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::RECVMMSG, "recvmmsg"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::RECVMSG, "recvmsg"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::REMAP_FILE_PAGES, "remap_file_pages"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::REMOVEXATTR, "removexattr"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::RENAME, "rename"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::RENAMEAT, "renameat"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::RENAMEAT2, "renameat2"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::REQUEST_KEY, "request_key"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::RESTART_SYSCALL, "restart_syscall"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::RMDIR, "rmdir"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::RT_SIGACTION, "rt_sigaction"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::RT_SIGPENDING, "rt_sigpending"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::RT_SIGPROCMASK, "rt_sigprocmask"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::RT_SIGQUEUEINFO, "rt_sigqueueinfo"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::RT_SIGRETURN, "rt_sigreturn"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::RT_SIGSUSPEND, "rt_sigsuspend"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::RT_SIGTIMEDWAIT, "rt_sigtimedwait"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::RT_TGSIGQUEUEINFO, "rt_tgsigqueueinfo"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SCHED_GET_PRIORITY_MAX, "sched_get_priority_max"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SCHED_GET_PRIORITY_MIN, "sched_get_priority_min"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SCHED_GETAFFINITY, "sched_getaffinity"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SCHED_GETATTR, "sched_getattr"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SCHED_GETPARAM, "sched_getparam"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SCHED_GETSCHEDULER, "sched_getscheduler"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SCHED_RR_GET_INTERVAL, "sched_rr_get_interval"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SCHED_SETAFFINITY, "sched_setaffinity"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SCHED_SETATTR, "sched_setattr"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SCHED_SETPARAM, "sched_setparam"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SCHED_SETSCHEDULER, "sched_setscheduler"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SCHED_YIELD, "sched_yield"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SECCOMP, "seccomp"),
+        #[cfg(any(target_arch = "x86_64"))]
+        (sc::nr::SECURITY, "security"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+        (sc::nr::SELECT, "select"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64"))]
+        (sc::nr::SEMCTL, "semctl"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64"))]
+        (sc::nr::SEMGET, "semget"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64"))]
+        (sc::nr::SEMOP, "semop"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64"))]
+        (sc::nr::SEMTIMEDOP, "semtimedop"),
+        #[cfg(any(target_arch = "arm"))]
+        (sc::nr::SEND, "send"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SENDFILE, "sendfile"),
+        #[cfg(any(target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::SENDFILE64, "sendfile64"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SENDMMSG, "sendmmsg"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SENDMSG, "sendmsg"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SENDTO, "sendto"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SET_MEMPOLICY, "set_mempolicy"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SET_ROBUST_LIST, "set_robust_list"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+        (sc::nr::SET_THREAD_AREA, "set_thread_area"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SET_TID_ADDRESS, "set_tid_address"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SETDOMAINNAME, "setdomainname"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SETFSGID, "setfsgid"),
+        #[cfg(any(target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::SETFSGID32, "setfsgid32"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SETFSUID, "setfsuid"),
+        #[cfg(any(target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::SETFSUID32, "setfsuid32"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SETGID, "setgid"),
+        #[cfg(any(target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::SETGID32, "setgid32"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SETGROUPS, "setgroups"),
+        #[cfg(any(target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::SETGROUPS32, "setgroups32"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SETHOSTNAME, "sethostname"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SETITIMER, "setitimer"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SETNS, "setns"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SETPGID, "setpgid"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SETPRIORITY, "setpriority"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SETREGID, "setregid"),
+        #[cfg(any(target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::SETREGID32, "setregid32"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SETRESGID, "setresgid"),
+        #[cfg(any(target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::SETRESGID32, "setresgid32"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SETRESUID, "setresuid"),
+        #[cfg(any(target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::SETRESUID32, "setresuid32"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SETREUID, "setreuid"),
+        #[cfg(any(target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::SETREUID32, "setreuid32"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SETRLIMIT, "setrlimit"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SETSID, "setsid"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SETSOCKOPT, "setsockopt"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SETTIMEOFDAY, "settimeofday"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SETUID, "setuid"),
+        #[cfg(any(target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::SETUID32, "setuid32"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SETXATTR, "setxattr"),
+        #[cfg(any(target_arch = "x86"))]
+        (sc::nr::SGETMASK, "sgetmask"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64"))]
+        (sc::nr::SHMAT, "shmat"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64"))]
+        (sc::nr::SHMCTL, "shmctl"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64"))]
+        (sc::nr::SHMDT, "shmdt"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64"))]
+        (sc::nr::SHMGET, "shmget"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SHUTDOWN, "shutdown"),
+        #[cfg(any(target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::SIGACTION, "sigaction"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SIGALTSTACK, "sigaltstack"),
+        #[cfg(any(target_arch = "x86"))]
+        (sc::nr::SIGNAL, "signal"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::SIGNALFD, "signalfd"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SIGNALFD4, "signalfd4"),
+        #[cfg(any(target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::SIGPENDING, "sigpending"),
+        #[cfg(any(target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::SIGPROCMASK, "sigprocmask"),
+        #[cfg(any(target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::SIGRETURN, "sigreturn"),
+        #[cfg(any(target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::SIGSUSPEND, "sigsuspend"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SOCKET, "socket"),
+        #[cfg(any(target_arch = "x86"))]
+        (sc::nr::SOCKETCALL, "socketcall"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SOCKETPAIR, "socketpair"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SPLICE, "splice"),
+        #[cfg(any(target_arch = "x86"))]
+        (sc::nr::SSETMASK, "ssetmask"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::STAT, "stat"),
+        #[cfg(any(target_arch = "arm", target_arch = "x86"))]
         (sc::nr::STAT64, "stat64"),
-        #[cfg(any(target_arch = "x86", target_arch = "arm"))]
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::STATFS, "statfs"),
+        #[cfg(any(target_arch = "arm", target_arch = "x86"))]
         (sc::nr::STATFS64, "statfs64"),
-        #[cfg(any(target_arch = "x86", target_arch = "arm"))]
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::STATX, "statx"),
+        #[cfg(any(target_arch = "x86"))]
+        (sc::nr::STIME, "stime"),
+        #[cfg(any(target_arch = "x86"))]
+        (sc::nr::STTY, "stty"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SWAPOFF, "swapoff"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SWAPON, "swapon"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::SYMLINK, "symlink"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SYMLINKAT, "symlinkat"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SYNC, "sync"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SYNC_FILE_RANGE, "sync_file_range"),
+        #[cfg(any(target_arch = "arm"))]
+        (sc::nr::SYNC_FILE_RANGE2, "sync_file_range2"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SYNCFS, "syncfs"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::SYSFS, "sysfs"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SYSINFO, "sysinfo"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::SYSLOG, "syslog"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::TEE, "tee"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::TGKILL, "tgkill"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+        (sc::nr::TIME, "time"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::TIMER_CREATE, "timer_create"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::TIMER_DELETE, "timer_delete"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::TIMER_GETOVERRUN, "timer_getoverrun"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::TIMER_GETTIME, "timer_gettime"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::TIMER_SETTIME, "timer_settime"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::TIMERFD_CREATE, "timerfd_create"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::TIMERFD_GETTIME, "timerfd_gettime"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::TIMERFD_SETTIME, "timerfd_settime"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::TIMES, "times"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::TKILL, "tkill"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::TRUNCATE, "truncate"),
+        #[cfg(any(target_arch = "arm", target_arch = "x86"))]
         (sc::nr::TRUNCATE64, "truncate64"),
-        #[cfg(any(target_arch = "x86", target_arch = "arm"))]
-        (sc::nr::LCHOWN32, "lchown32"),
-        #[cfg(any(target_arch = "x86", target_arch = "arm"))]
-        (sc::nr::LSTAT64, "lstat64"),
+        #[cfg(any(target_arch = "x86_64"))]
+        (sc::nr::TUXCALL, "tuxcall"),
+        #[cfg(any(target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::UGETRLIMIT, "ugetrlimit"),
+        #[cfg(any(target_arch = "x86"))]
+        (sc::nr::ULIMIT, "ulimit"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::UMASK, "umask"),
+        #[cfg(any(target_arch = "x86"))]
+        (sc::nr::UMOUNT, "umount"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::UMOUNT2, "umount2"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::UNAME, "uname"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::UNLINK, "unlink"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::UNLINKAT, "unlinkat"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::UNSHARE, "unshare"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::USELIB, "uselib"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::USERFAULTFD, "userfaultfd"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::USTAT, "ustat"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+        (sc::nr::UTIME, "utime"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::UTIMENSAT, "utimensat"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::UTIMES, "utimes"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::VFORK, "vfork"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::VHANGUP, "vhangup"),
+        #[cfg(any(target_arch = "x86"))]
+        (sc::nr::VM86, "vm86"),
+        #[cfg(any(target_arch = "x86"))]
+        (sc::nr::VM86OLD, "vm86old"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::VMSPLICE, "vmsplice"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "x86"))]
+        (sc::nr::VSERVER, "vserver"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::WAIT4, "wait4"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::WAITID, "waitid"),
+        #[cfg(any(target_arch = "x86"))]
+        (sc::nr::WAITPID, "waitpid"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::WRITE, "write"),
+        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
+        (sc::nr::WRITEV, "writev"),
     ]
     .iter()
     .cloned()

--- a/src/kernel/syscall.rs
+++ b/src/kernel/syscall.rs
@@ -744,8 +744,6 @@ lazy_static! {
         (sc::nr::SYNC, "sync"),
         #[cfg(any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::SYNC_FILE_RANGE, "sync_file_range"),
-        #[cfg(any(target_arch = "arm"))]
-        (sc::nr::SYNC_FILE_RANGE2, "sync_file_range2"),
         #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64", target_arch = "x86"))]
         (sc::nr::SYNCFS, "syncfs"),
         #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "x86"))]

--- a/src/register/abi.rs
+++ b/src/register/abi.rs
@@ -1,93 +1,140 @@
 /// Specify the ABI registers (syscall argument passing, stack pointer).
 /// See sysdeps/unix/sysv/linux/${ARCH}/syscall.S from the GNU C Library.
-#[cfg(all(target_os = "linux", any(target_arch = "x86_64")))]
+#[cfg(all(
+    any(target_os = "linux", target_os = "android"),
+    any(target_arch = "x86_64")
+))]
 #[macro_use]
 pub mod regs_offset {
     macro_rules! get_reg {
         ($regs:expr, SysNum) => {
-            $regs.orig_rax
+            $regs.0.orig_rax
         };
         ($regs:expr, SysArg1) => {
-            $regs.rdi
+            $regs.0.rdi
         };
         ($regs:expr, SysArg2) => {
-            $regs.rsi
+            $regs.0.rsi
         };
         ($regs:expr, SysArg3) => {
-            $regs.rdx
+            $regs.0.rdx
         };
         ($regs:expr, SysArg4) => {
-            $regs.r10
+            $regs.0.r10
         };
         ($regs:expr, SysArg5) => {
-            $regs.r8
+            $regs.0.r8
         };
         ($regs:expr, SysArg6) => {
-            $regs.r9
+            $regs.0.r9
         };
         ($regs:expr, SysResult) => {
-            $regs.rax
+            $regs.0.rax
         };
         ($regs:expr, StackPointer) => {
-            $regs.rsp
+            $regs.0.rsp
         };
         ($regs:expr, InstrPointer) => {
-            $regs.rip
+            $regs.0.rip
         };
         ($regs:expr, RtldFini) => {
-            $regs.rdx
+            $regs.0.rdx
         };
         ($regs:expr, StateFlags) => {
-            $regs.eflags
+            $regs.0.eflags
         };
         ($regs:expr, UserArg1) => {
-            $regs.rdi
+            $regs.0.rdi
         };
     }
 }
 
-#[cfg(all(target_os = "linux", any(target_arch = "x86")))]
+#[cfg(all(
+    any(target_os = "linux", target_os = "android"),
+    any(target_arch = "x86")
+))]
 #[macro_use]
 pub mod regs_offset {
     macro_rules! get_reg {
         ($regs:expr, SysNum) => {
-            $regs.orig_eax
+            $regs.0.orig_eax
         };
         ($regs:expr, SysArg1) => {
-            $regs.ebx
+            $regs.0.ebx
         };
         ($regs:expr, SysArg2) => {
-            $regs.ecx
+            $regs.0.ecx
         };
         ($regs:expr, SysArg3) => {
-            $regs.edx
+            $regs.0.edx
         };
         ($regs:expr, SysArg4) => {
-            $regs.esi
+            $regs.0.esi
         };
         ($regs:expr, SysArg5) => {
-            $regs.edi
+            $regs.0.edi
         };
         ($regs:expr, SysArg6) => {
-            $regs.ebp
+            $regs.0.ebp
         };
         ($regs:expr, SysResult) => {
-            $regs.eax
+            $regs.0.eax
         };
         ($regs:expr, StackPointer) => {
-            $regs.esp
+            $regs.0.esp
         };
         ($regs:expr, InstrPointer) => {
-            $regs.eip
+            $regs.0.eip
         };
         ($regs:expr, RtldFini) => {
-            $regs.edx
+            $regs.0.edx
         };
         ($regs:expr, StateFlags) => {
-            $regs.eflags
+            $regs.0.eflags
         };
         ($regs:expr, UserArg1) => {
-            $regs.eax
+            $regs.0.eax
+        };
+    }
+}
+
+/// https://chromium.googlesource.com/chromiumos/docs/+/master/constants/syscalls.md#calling-conventions
+#[cfg(all(
+    any(target_os = "linux", target_os = "android"),
+    any(target_arch = "arm")
+))]
+#[macro_use]
+pub mod regs_offset {
+    macro_rules! get_reg {
+        ($regs:expr, SysNum) => {
+            $regs.0[7]
+        };
+        ($regs:expr, SysArg1) => {
+            $regs.0[0]
+        };
+        ($regs:expr, SysArg2) => {
+            $regs.0[1]
+        };
+        ($regs:expr, SysArg3) => {
+            $regs.0[2]
+        };
+        ($regs:expr, SysArg4) => {
+            $regs.0[3]
+        };
+        ($regs:expr, SysArg5) => {
+            $regs.0[4]
+        };
+        ($regs:expr, SysArg6) => {
+            $regs.0[5]
+        };
+        ($regs:expr, SysResult) => {
+            $regs.0[0]
+        };
+        ($regs:expr, StackPointer) => {
+            $regs.0[13]
+        };
+        ($regs:expr, InstrPointer) => {
+            $regs.0[15]
         };
     }
 }

--- a/src/register/mem.rs
+++ b/src/register/mem.rs
@@ -68,15 +68,15 @@ impl PtraceMemoryAllocator for Registers {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::register::regs::RegisterSet;
     use crate::register::Registers;
-    use libc::user_regs_struct;
     use nix::unistd::getpid;
     use std::mem;
     use std::usize::MAX;
 
     #[test]
     fn test_mem_alloc_normal() {
-        let mut raw_regs: user_regs_struct = unsafe { mem::zeroed() };
+        let mut raw_regs: RegisterSet = unsafe { mem::zeroed() };
         let starting_stack_pointer = 100000;
 
         get_reg!(raw_regs, StackPointer) = starting_stack_pointer;
@@ -98,7 +98,7 @@ mod tests {
 
     #[test]
     fn test_mem_alloc_overflow() {
-        let mut raw_regs: user_regs_struct = unsafe { mem::zeroed() };
+        let mut raw_regs: RegisterSet = unsafe { mem::zeroed() };
         let starting_stack_pointer = 120;
 
         get_reg!(raw_regs, StackPointer) = starting_stack_pointer;
@@ -121,7 +121,7 @@ mod tests {
 
     #[test]
     fn test_mem_alloc_underflow() {
-        let mut raw_regs: user_regs_struct = unsafe { mem::zeroed() };
+        let mut raw_regs: RegisterSet = unsafe { mem::zeroed() };
         let starting_stack_pointer = (MAX as Word) - 120;
 
         get_reg!(raw_regs, StackPointer) = starting_stack_pointer;

--- a/src/register/reader.rs
+++ b/src/register/reader.rs
@@ -175,7 +175,8 @@ mod tests {
     #[cfg(target_pointer_width = "32")]
     fn test_reader_convert_word_to_bytes() {
         let number: Word =
-            'h' as u64 + 'e' as u64 * 256 + 'l' as u64 * 256 * 256 + 'o' as u64 * 256 * 256 * 256;
+            ('h' as u64 + 'e' as u64 * 256 + 'l' as u64 * 256 * 256 + 'o' as u64 * 256 * 256 * 256)
+                as Word;
         let bytes = convert_word_to_bytes(number);
 
         assert_eq!(bytes, ['h' as u8, 'e' as u8, 'l' as u8, 'o' as u8]);

--- a/src/register/reader.rs
+++ b/src/register/reader.rs
@@ -150,9 +150,9 @@ fn read_string(pid: Pid, src_string: *mut Word, max_size: usize) -> Result<Vec<u
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::register::regs::RegisterSet;
     use crate::register::*;
     use crate::utils::tests::{fork_test, get_test_rootfs_path};
-    use libc::user_regs_struct;
     use nix::unistd::{execvp, getpid};
     use sc::nr::MKDIR;
     use std::ffi::CString;
@@ -183,7 +183,7 @@ mod tests {
 
     #[test]
     fn test_reader_get_sysarg_path_return_empty_if_given_null_src_() {
-        let raw_regs: user_regs_struct = unsafe { mem::zeroed() };
+        let raw_regs: RegisterSet = unsafe { mem::zeroed() };
         let regs = Registers::from(getpid(), raw_regs);
         let args = [SysArg1, SysArg2, SysArg3, SysArg4, SysArg5, SysArg6];
 

--- a/src/register/regs.rs
+++ b/src/register/regs.rs
@@ -4,7 +4,7 @@ use std::mem::MaybeUninit;
 use libc::c_void;
 use nix::unistd::Pid;
 
-use crate::errors::Result;
+use crate::errors::*;
 use crate::register::Word;
 
 const VOID: Word = Word::MAX;

--- a/tests/bind.bats
+++ b/tests/bind.bats
@@ -5,27 +5,27 @@ load helper
 
 @test "test bind dir to dir" {
     # bind /etc to /home
-    proot-rs --bind "/etc:/home" -- /bin/sh -c "/bin/diff /etc /home"
+    proot-rs --bind "/etc:/home" -- /bin/sh -c "$(which diff) /etc /home"
 }
 
 
 @test "test bind file to file" {
     # bind /etc/group to /etc/passwd
-    proot-rs --bind "/etc/group:/etc/passwd" -- /bin/sh -c "/bin/diff /etc/group /etc/passwd"
+    proot-rs --bind "/etc/group:/etc/passwd" -- /bin/sh -c "$(which diff) /etc/group /etc/passwd"
 }
 
 
 @test "test bind dir to file" {
     # bind /home to /etc/passwd
     # this may seem odd, but it is allowed
-    proot-rs --bind "/home:/etc/passwd" -- /bin/sh -c "/bin/diff /home /etc/passwd"
+    proot-rs --bind "/home:/etc/passwd" -- /bin/sh -c "$(which diff) /home /etc/passwd"
 }
 
 
 @test "test bind file to dir" {
     # bind /etc/passwd to /home
     # this may seem odd, but it is allowed
-    proot-rs --bind "/etc/passwd:/home" -- /bin/sh -c "/bin/diff /etc/passwd /home"
+    proot-rs --bind "/etc/passwd:/home" -- /bin/sh -c "$(which diff) /etc/passwd /home"
 }
 
 
@@ -45,7 +45,7 @@ load helper
     chmod 777 "$ROOTFS/tmp/test_bind_with_getdents64/file2"
     # bind "$ROOTFS/tmp/test_bind_with_getdents64/file1" to "/tmp/test_bind_with_getdents64/file2"
     runp proot-rs --rootfs "$ROOTFS" --bind "$ROOTFS/tmp/test_bind_with_getdents64/file1:/tmp/test_bind_with_getdents64/file2" -- /bin/sh -e -c ' \
-        PATH=/bin
+        PATH=/usr/local/bin:/usr/bin:/bin
         # Get the output of ls -l and filter out the lines related to file1 and file2
         output=$(ls -l /tmp/test_bind_with_getdents64 | grep "file" | sed  "s/file.*//g") \
         # The $output should contain two lines

--- a/tests/cli.bats
+++ b/tests/cli.bats
@@ -26,7 +26,7 @@ load helper
 }
 
 @test "test proot-rs options --bind" {
-    proot-rs --bind "/etc:/home" -- /bin/stat /home/passwd
-    proot-rs -b "/etc:/home" -- /bin/stat /home/passwd
+    proot-rs --bind "/etc:/home" -- "$(which stat)" /home/passwd
+    proot-rs -b "/etc:/home" -- "$(which stat)" /home/passwd
 }
 

--- a/tests/execve/test.bats
+++ b/tests/execve/test.bats
@@ -24,7 +24,7 @@ load ../helper
 
 
 function script_test_run_script_with_shebang {
-    PATH=/bin
+    PATH=/usr/local/bin:/usr/bin:/bin
 
     cd /tmp/test_run_script_with_shebang
 
@@ -89,7 +89,7 @@ function script_test_run_script_with_shebang {
 
 @test "test run script with shebang" {
     local test_dir="$ROOTFS/tmp/test_run_script_with_shebang"
-    mkdir "$test_dir"
+    mkdir -p "$test_dir"
     runp proot-rs --rootfs "$ROOTFS" -- /bin/sh -e -x -c "$(declare -f script_test_run_script_with_shebang); script_test_run_script_with_shebang"
     rm -rf "$test_dir"
     [ "$status" -eq 0 ]

--- a/tests/helper.bash
+++ b/tests/helper.bash
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export LC_ALL=C
+
 # The root directory where the integration test files are placed
 TEST_ROOT=$(dirname "$(readlink -f "$BASH_SOURCE")")
 
@@ -30,14 +32,19 @@ function proot-rs() {
 
 # Compile a single C source code file ($2) to statically linked binary ($1)
 function compile_c_static() {
-    local target_path=$1
-    local source_path=$2
+    local target_path="$1"
+    local source_path="$2"
     gcc -static -o "$target_path" "$source_path"
 }
 
 # Same as `compile_c_static()`, but the final binary is dynamically linked
 function compile_c_dynamic() {
-    local target_path=$1
-    local source_path=$2
+    local target_path="$1"
+    local source_path="$2"
     gcc -o "$target_path" "$source_path"
+}
+
+# Ensure that the command exists, or skip the test
+function check_if_command_exists() {
+    command -v "$1" 1>&- 2>&- || { skip "The command \`$1\` is required but is not installed."; }
 }


### PR DESCRIPTION
The changes included in this PR are intended to add support for the `arm-unknown-linux-musleabi` target to proot-rs.

The main changes are:
- Add conditional compilation statements for different architectures due to differences in system calls.
- Add missing parts for `loader.c`.
- ptrace(): added support for reading and writing register sets on arm target.
- Some additional fixes such as changes to the types of some variables.