### PR TITLE
Improve cross compilation

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,9 @@
 [target.arm-unknown-linux-musleabi]
 linker = "arm-linux-musleabi-gcc"
 
+[target.aarch64-unknown-linux-musl]
+linker = "aarch64-linux-musl-gcc"
+
 [target.arm-linux-androideabi]
 linker = "armv7a-linux-androideabi21-clang"
 

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,8 +1,8 @@
-[target.arm-unknown-linux-musleabi]
-linker = "arm-linux-musleabi-gcc"
+[target.i686-linux-android]
+linker = "i686-linux-android21-clang"
 
-[target.aarch64-unknown-linux-musl]
-linker = "aarch64-linux-musl-gcc"
+[target.x86_64-linux-android]
+linker = "x86_64-linux-android21-clang"
 
 [target.arm-linux-androideabi]
 linker = "armv7a-linux-androideabi21-clang"

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,9 @@
+[build.env]
+passthrough = [
+    "RUST_BACKTRACE",
+    "RUST_LOG",
+    "TRAVIS",
+    "RUSTFLAGS",
+    "PROOT_TEST_ROOTFS",
+    "PROOT_RS",
+]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ ENV PATH "/root/.cargo/bin/:/opt/android-sdk-linux/ndk-bundle/toolchains/llvm/pr
 RUN rustup-init -y && \
     rustup toolchain install stable && \
     cargo +stable install --force cargo-make && \
+    cargo install cross && \
     rustup toolchain install nightly-2021-03-24 && \
     rustup +nightly-2021-03-24 target add arm-linux-androideabi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,18 @@ RUN rustup-init -y && \
     cargo +stable install --force cargo-make && \
     cargo install cross && \
     rustup toolchain install nightly-2021-03-24 && \
-    rustup +nightly-2021-03-24 target add arm-linux-androideabi
+    rustup +nightly-2021-03-24 target add x86_64-unknown-linux-musl && \
+    rustup +nightly-2021-03-24 target add x86_64-unknown-linux-gnu && \
+    rustup +nightly-2021-03-24 target add x86_64-linux-android && \
+    rustup +nightly-2021-03-24 target add i686-unknown-linux-musl && \
+    rustup +nightly-2021-03-24 target add i686-unknown-linux-gnu && \
+    rustup +nightly-2021-03-24 target add i686-linux-android && \
+    rustup +nightly-2021-03-24 target add armv7-unknown-linux-musleabihf && \
+    rustup +nightly-2021-03-24 target add armv7-unknown-linux-gnueabihf && \
+    rustup +nightly-2021-03-24 target add arm-linux-androideabi && \
+    rustup +nightly-2021-03-24 target add aarch64-unknown-linux-musl && \
+    rustup +nightly-2021-03-24 target add aarch64-unknown-linux-gnu && \
+    rustup +nightly-2021-03-24 target add aarch64-linux-android
 
 WORKDIR /usr/src/proot-rs
 COPY . /usr/src/proot-rs

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,14 +9,15 @@ RUN apk update && \
             rustup \
             shellcheck \
             openssl-dev \
-            musl-dev
+            musl-dev \
+            docker
 
 ENV PATH "/root/.cargo/bin/:/opt/android-sdk-linux/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/bin:${PATH}"
 
 RUN rustup-init -y && \
     rustup toolchain install stable && \
     cargo +stable install --force cargo-make && \
-    cargo install cross && \
+    cargo +stable install --git="https://github.com/rust-embedded/cross.git" --branch="master" cross && \
     rustup toolchain install nightly-2021-03-24 && \
     rustup +nightly-2021-03-24 target add x86_64-unknown-linux-musl && \
     rustup +nightly-2021-03-24 target add x86_64-unknown-linux-gnu && \
@@ -33,6 +34,8 @@ RUN rustup-init -y && \
 
 WORKDIR /usr/src/proot-rs
 COPY . /usr/src/proot-rs
+
+ENV CROSS_DOCKER_IN_DOCKER=true
 
 CMD ["cargo", "make", "build"]
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,13 +1,16 @@
 [env]
 CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
+# override $CARGO with "cross"
+CARGO = { value = "cross", condition = { env_true = ["USE_CROSS"] } }
+CARGO_EXTRA_FLAGS_TARGET = { value = "--target=${CARGO_BUILD_TARGET}", condition = { env_set = ["CARGO_BUILD_TARGET"] } }
 
 [env.development]
 OUTPUT_DIR_NAME = "debug"
-CARGO_EXTRA_FLAGS = []
+CARGO_EXTRA_FLAGS = "${CARGO_EXTRA_FLAGS_TARGET}"
 
 [env.production]
 OUTPUT_DIR_NAME = "release"
-CARGO_EXTRA_FLAGS = ["--release"]
+CARGO_EXTRA_FLAGS = "${CARGO_EXTRA_FLAGS_TARGET} --release"
 
 [config]
 default_to_workspace = false
@@ -16,7 +19,7 @@ default_to_workspace = false
 dependencies = ["build"]
 script_runner = "@shell"
 script = '''
-cargo run --bin=proot-rs ${CARGO_EXTRA_FLAGS} -- ${@}
+"$CARGO" run --bin=proot-rs ${CARGO_EXTRA_FLAGS} -- ${@}
 '''
 
 [tasks.build]
@@ -24,7 +27,7 @@ clear = true
 dependencies = ["build-loader", "copy-loader"]
 script_runner = "@shell"
 script = '''
-cargo build --bin=proot-rs ${CARGO_EXTRA_FLAGS}
+"$CARGO" build --bin=proot-rs ${CARGO_EXTRA_FLAGS}
 echo -e "proot-rs:\t$(realpath target/${CARGO_BUILD_TARGET}/${OUTPUT_DIR_NAME}/proot-rs)"
 echo -e "loader-shim:\t$(realpath target/${CARGO_BUILD_TARGET}/${OUTPUT_DIR_NAME}/loader-shim)"
 '''
@@ -32,7 +35,7 @@ echo -e "loader-shim:\t$(realpath target/${CARGO_BUILD_TARGET}/${OUTPUT_DIR_NAME
 [tasks.build-loader]
 script_runner = "@shell"
 script = '''
-RUSTFLAGS="-C panic=abort -C link-self-contained=no" cargo build --bin=loader-shim --features="build-binary" ${CARGO_EXTRA_FLAGS}
+RUSTFLAGS="-C panic=abort -C link-self-contained=no" "$CARGO" build --bin=loader-shim --features="build-binary" ${CARGO_EXTRA_FLAGS}
 '''
 
 [tasks.copy-loader]
@@ -52,7 +55,7 @@ script = '''
 if [ -z "${PROOT_TEST_ROOTFS}" ]; then
     export PROOT_TEST_ROOTFS="$(pwd)/rootfs"
 fi
-cargo test --package=proot-rs ${CARGO_EXTRA_FLAGS}
+"$CARGO" test --package=proot-rs ${CARGO_EXTRA_FLAGS}
 '''
 
 [tasks.integration-test]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,16 +1,26 @@
+env_scripts = [
+'''
+#!@duckscript
+
+if not is_empty "${CARGO_BUILD_TARGET}"
+    set_env CARGO_EXTRA_FLAGS "${CARGO_EXTRA_FLAGS} --target=${CARGO_BUILD_TARGET}"
+end
+'''
+]
+
 [env]
 CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
 # override $CARGO with "cross"
 CARGO = { value = "cross", condition = { env_true = ["USE_CROSS"] } }
-CARGO_EXTRA_FLAGS_TARGET = { value = "--target=${CARGO_BUILD_TARGET}", condition = { env_set = ["CARGO_BUILD_TARGET"] } }
 
 [env.development]
 OUTPUT_DIR_NAME = "debug"
-CARGO_EXTRA_FLAGS = "${CARGO_EXTRA_FLAGS_TARGET}"
+CARGO_EXTRA_FLAGS = ""
 
 [env.production]
 OUTPUT_DIR_NAME = "release"
-CARGO_EXTRA_FLAGS = "${CARGO_EXTRA_FLAGS_TARGET} --release"
+CARGO_EXTRA_FLAGS = "--release"
+
 
 [config]
 default_to_workspace = false

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -21,7 +21,7 @@ cargo run --bin=proot-rs ${CARGO_EXTRA_FLAGS} -- ${@}
 
 [tasks.build]
 clear = true
-dependencies = ["copy-loader", "build-loader"]
+dependencies = ["build-loader", "copy-loader"]
 script_runner = "@shell"
 script = '''
 cargo build --bin=proot-rs ${CARGO_EXTRA_FLAGS}

--- a/README.md
+++ b/README.md
@@ -102,10 +102,40 @@ cargo make build --profile=production
 
 Currently `proot-rs` supports multiple platforms. You can change the compilation target by setting the environment variable `CARGO_BUILD_TARGET`.
 
-For example, compiling to the `arm-linux-androideabi` target:
-```shell
-CARGO_BUILD_TARGET=arm-linux-androideabi cargo make build
-```
+#### With [`cross`](https://github.com/rust-embedded/cross) (Recommended)
+
+The `cross` is a “zero setup” cross compilation and “cross testing” tool, which uses docker to provide an out-of-the-box cross-compilation environment.
+
+- To use cross, you may need to install it first:
+
+    ```shell
+    cargo install cross
+    ```
+
+- Run with `USE_CROSS=true`
+
+  Our `Makefile.toml` script contains the integration with `cross`.
+
+  For example, to compile to the `arm-linux-androideabi` target, you can simply run:
+  ```shell
+  USE_CROSS=true CARGO_BUILD_TARGET=arm-linux-androideabi cargo make build
+  ```
+  > The `USE_CROSS=true` will indicate the build script to use the `cross` tool to compile.
+
+#### With `cargo` (Native Approach)
+
+You can also use the rust native approach to cross-compile proot-rs.
+
+For example, to compile to the `arm-linux-androideabi` target
+- Install this target first:
+  ```shell
+  rustup target add arm-linux-androideabi
+  ```
+- Cross compile with `cargo`
+  ```shell
+  CARGO_BUILD_TARGET=arm-linux-androideabi cargo make build
+  ```
+  > Note: This command may fail for compiling to some targets because the linker reports some error. In this case, You may need to install an additional gcc/clang toolchain on your computer, and specify the appropriate linker path in the `.cargo/config.toml` file
 
 <!-- TODO: Try to compile and test multiple targets in CI, and crate a table here. -->
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,9 @@ Currently `proot-rs` supports multiple platforms. You can change the compilation
 
 #### With [`cross`](https://github.com/rust-embedded/cross) (Recommended)
 
-The `cross` is a “zero setup” cross compilation and “cross testing” tool, which uses docker to provide an out-of-the-box cross-compilation environment.
+The `cross` is a “zero setup” cross compilation and “cross testing” tool, which uses docker to provide an out-of-the-box cross-compilation environment which contains a ready-to-use cross-compilation toolchain. So we don't need to prepare it ourselves.
+
+> Note that `cross` depends on docker, so you need to install docker and start it.
 
 - To use cross, you may need to install it first:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ version: "3.5"
 services:
   proot-rs-sdk:
     container_name: proot-rs-sdk
-    hostname: proot-rs-sdk
     build: .
     image: proot/proot-rs-sdk:latest
     volumes:
@@ -12,7 +11,6 @@ services:
         target: /var/run/docker.sock
   proot-rs-test:
     container_name: proot-rs-test
-    hostname: proot-rs-test
     build: ./tests
     image: proot/proot-rs-test:latest
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.5"
 services:
   proot-rs-sdk:
     container_name: proot-rs-sdk

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,9 @@ services:
     image: proot/proot-rs-sdk:latest
     volumes:
       - ~/src/proot-rs/:/usr/src/proot-rs
+      - type: bind
+        source: /var/run/docker.sock
+        target: /var/run/docker.sock
   proot-rs-test:
     container_name: proot-rs-test
     hostname: proot-rs-test
@@ -14,4 +17,7 @@ services:
     image: proot/proot-rs-test:latest
     volumes:
       - ~/src/proot-rs/:/usr/src/proot-rs
+      - type: bind
+        source: /var/run/docker.sock
+        target: /var/run/docker.sock
 

--- a/loader-shim/src/main.rs
+++ b/loader-shim/src/main.rs
@@ -10,6 +10,7 @@
 
 #[allow(unused_attributes)]
 // Only static links are used and prevent linking with the shared libraries.
+#[link_args = "-no-pie"]
 #[link_args = "-static"]
 // Disable system startup files or libraries when linking. This means
 // that the linker will not include files like `crt0.o` and some of the

--- a/proot-rs/src/kernel/groups.rs
+++ b/proot-rs/src/kernel/groups.rs
@@ -2,6 +2,7 @@
 /// It's easier and cleaner to use cfg conditions here rather than in the huge
 /// match in `translate_syscall_enter` and `translate_syscall_exit`.
 #[derive(Debug, PartialEq)]
+#[allow(dead_code)]
 pub enum SyscallGroup {
     Ignored = 0,
     Execve,

--- a/proot-rs/src/register/abi.rs
+++ b/proot-rs/src/register/abi.rs
@@ -138,3 +138,44 @@ pub mod regs_offset {
         };
     }
 }
+
+/// https://chromium.googlesource.com/chromiumos/docs/+/master/constants/syscalls.md#calling-conventions
+#[cfg(all(
+    any(target_os = "linux", target_os = "android"),
+    any(target_arch = "aarch64")
+))]
+#[macro_use]
+pub mod regs_offset {
+    macro_rules! get_reg {
+        ($regs:expr, SysNum) => {
+            $regs.regs[8]
+        };
+        ($regs:expr, SysArg1) => {
+            $regs.regs[0]
+        };
+        ($regs:expr, SysArg2) => {
+            $regs.regs[1]
+        };
+        ($regs:expr, SysArg3) => {
+            $regs.regs[2]
+        };
+        ($regs:expr, SysArg4) => {
+            $regs.regs[3]
+        };
+        ($regs:expr, SysArg5) => {
+            $regs.regs[4]
+        };
+        ($regs:expr, SysArg6) => {
+            $regs.regs[5]
+        };
+        ($regs:expr, SysResult) => {
+            $regs.regs[0]
+        };
+        ($regs:expr, StackPointer) => {
+            $regs.sp
+        };
+        ($regs:expr, InstrPointer) => {
+            $regs.pc
+        };
+    }
+}


### PR DESCRIPTION
This PR enables proot-rs to be easily cross-compiled:
- Fix some compilation failures in the project's cross-compilation. https://github.com/proot-me/proot-rs/issues/35
- Integrate  tool [`cross`](https://github.com/rust-embedded/cross) into `Makefile.toml`

It is now possible to compile proot-rs to the 12 targets mentioned here: https://github.com/proot-me/proot-rs/issues/52#issuecomment-896924392

```shell
USE_CROSS=true CARGO_BUILD_TARGET=x86_64-unknown-linux-musl cargo make build
USE_CROSS=true CARGO_BUILD_TARGET=x86_64-unknown-linux-gnu cargo make build
USE_CROSS=true CARGO_BUILD_TARGET=x86_64-linux-android cargo make build
USE_CROSS=true CARGO_BUILD_TARGET=i686-unknown-linux-musl cargo make build
USE_CROSS=true CARGO_BUILD_TARGET=i686-unknown-linux-gnu cargo make build
USE_CROSS=true CARGO_BUILD_TARGET=i686-linux-android cargo make build
USE_CROSS=true CARGO_BUILD_TARGET=armv7-unknown-linux-musleabihf cargo make build
USE_CROSS=true CARGO_BUILD_TARGET=armv7-unknown-linux-gnueabihf cargo make build
USE_CROSS=true CARGO_BUILD_TARGET=arm-linux-androideabi cargo make build
USE_CROSS=true CARGO_BUILD_TARGET=aarch64-unknown-linux-musl cargo make build
USE_CROSS=true CARGO_BUILD_TARGET=aarch64-unknown-linux-gnu cargo make build
USE_CROSS=true CARGO_BUILD_TARGET=aarch64-linux-android cargo make build

```

