### PR TITLE
Publish releases using GitHub workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,57 @@
+name: Publish
+
+on: [push, pull_request]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  cross-compile:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      matrix:
+        target:
+          - x86_64-unknown-linux-musl
+          - x86_64-unknown-linux-gnu
+          - x86_64-linux-android
+          - i686-unknown-linux-musl
+          - i686-unknown-linux-gnu
+          - i686-linux-android
+          - armv7-unknown-linux-musleabihf
+          - armv7-unknown-linux-gnueabihf
+          - arm-linux-androideabi
+          - aarch64-unknown-linux-musl
+          - aarch64-unknown-linux-gnu
+          - aarch64-linux-android
+    steps:
+    - uses: actions/checkout@v2
+    - uses: davidB/rust-cargo-make@v1.6.0
+    - name: Install cross
+      shell: bash
+      run: |
+        curl -L https://github.com/rust-embedded/cross/releases/download/v0.2.1/cross-v0.2.1-x86_64-unknown-linux-musl.tar.gz | tar -xzf - --to-stdout > ~/.cargo/bin/cross
+        chmod +x ~/.cargo/bin/cross
+    - name: Build proot-rs
+      shell: bash
+      run: |
+        USE_CROSS=true CARGO_BUILD_TARGET="${{ matrix.target }}" cargo make build --profile=production
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: proot-rs-${{ matrix.target }}
+        path: target/${{ matrix.target }}/release/proot-rs
+    - name: Compress binaries
+      # We only publish binaries when we create a tag
+      if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+      shell: bash
+      run: |
+        tar czvf proot-rs.tar.gz -C target/${{ matrix.target }}/release proot-rs
+    - name: Upload binaries to release
+      if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: proot-rs.tar.gz
+        asset_name: proot-rs-$tag-${{ matrix.target }}.tar.gz
+        tag: ${{ github.ref }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,12 +65,7 @@ jobs:
     timeout-minutes: 10
     steps:
     - uses: actions/checkout@v2
-    - name: Install cargo-make
-      uses: actions-rs/cargo@v1
-      with:
-        toolchain: stable
-        command: install
-        args: --debug cargo-make
+    - uses: davidB/rust-cargo-make@v1.6.0
     - name: Build
       run: cargo make build
     - name: Setup rootfs
@@ -90,7 +85,7 @@ jobs:
       run: |
         PROOT_TEST_ROOTFS="$(pwd)/rootfs" bats -r tests
 
-  cross-compile:
+  cross-compile: 
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -108,31 +103,19 @@ jobs:
           - aarch64-unknown-linux-gnu
           - aarch64-linux-android
     steps:
-      - uses: actions/checkout@v2
-      - name: Install cargo-make
-        uses: actions-rs/cargo@v1
-        with:
-          toolchain: stable
-          command: install
-          args: --debug cargo-make
-      - name: Build proot-rs
-        uses: actions-rs/cargo@v1
-        with:
-          command: make
-          args: build
-          use-cross: true
-        env:
-          USE_CROSS: true
-          CARGO_BUILD_TARGET: ${{ matrix.target }}
-      - name: Build archive
-        shell: bash
-        run: |
-          asset_name="proot-rs-${{ github.ref }}-${{ matrix.target }}"
-          cp "target/${{ matrix.target }}/debug/proot-rs" "${asset_name}"
-          tar czf "${asset_name}.tar.gz" "${asset_name}"
-          echo "ASSET=${asset_name}.tar.gz" >> $GITHUB_ENV
-      - name: Upload artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: proot-rs-${{ matrix.target }}
-          path: ${{ env.ASSET }}
+    - uses: actions/checkout@v2
+    - uses: davidB/rust-cargo-make@v1.6.0
+    - name: Install cross
+      shell: bash
+      run: |
+        curl -L https://github.com/rust-embedded/cross/releases/download/v0.2.1/cross-v0.2.1-x86_64-unknown-linux-musl.tar.gz | tar -xzf - --to-stdout > ~/.cargo/bin/cross
+        chmod +x ~/.cargo/bin/cross
+    - name: Build proot-rs
+      shell: bash
+      run: |
+        USE_CROSS=true CARGO_BUILD_TARGET="${{ matrix.target }}" cargo make build
+    - name: Upload artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: proot-rs-${{ matrix.target }}
+        path: target/${{ matrix.target }}/debug/proot-rs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,3 +89,50 @@ jobs:
       shell: bash
       run: |
         PROOT_TEST_ROOTFS="$(pwd)/rootfs" bats -r tests
+
+  cross-compile:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - x86_64-unknown-linux-musl
+          - x86_64-unknown-linux-gnu
+          - x86_64-linux-android
+          - i686-unknown-linux-musl
+          - i686-unknown-linux-gnu
+          - i686-linux-android
+          - armv7-unknown-linux-musleabihf
+          - armv7-unknown-linux-gnueabihf
+          - arm-linux-androideabi
+          - aarch64-unknown-linux-musl
+          - aarch64-unknown-linux-gnu
+          - aarch64-linux-android
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install cargo-make
+        uses: actions-rs/cargo@v1
+        with:
+          toolchain: stable
+          command: install
+          args: --debug cargo-make
+      - name: Build proot-rs
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: build
+          use-cross: true
+        env:
+          USE_CROSS: true
+          CARGO_BUILD_TARGET: ${{ matrix.target }}
+      - name: Build archive
+        shell: bash
+        run: |
+          asset_name="proot-rs-${{ github.ref }}-${{ matrix.target }}"
+          cp "target/${{ matrix.target }}/debug/proot-rs" "${asset_name}"
+          tar czf "${asset_name}.tar.gz" "${asset_name}"
+          echo "ASSET=${asset_name}.tar.gz" >> $GITHUB_ENV
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: proot-rs-${{ matrix.target }}
+          path: ${{ env.ASSET }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,38 +84,3 @@ jobs:
       shell: bash
       run: |
         PROOT_TEST_ROOTFS="$(pwd)/rootfs" bats -r tests
-
-  cross-compile: 
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        target:
-          - x86_64-unknown-linux-musl
-          - x86_64-unknown-linux-gnu
-          - x86_64-linux-android
-          - i686-unknown-linux-musl
-          - i686-unknown-linux-gnu
-          - i686-linux-android
-          - armv7-unknown-linux-musleabihf
-          - armv7-unknown-linux-gnueabihf
-          - arm-linux-androideabi
-          - aarch64-unknown-linux-musl
-          - aarch64-unknown-linux-gnu
-          - aarch64-linux-android
-    steps:
-    - uses: actions/checkout@v2
-    - uses: davidB/rust-cargo-make@v1.6.0
-    - name: Install cross
-      shell: bash
-      run: |
-        curl -L https://github.com/rust-embedded/cross/releases/download/v0.2.1/cross-v0.2.1-x86_64-unknown-linux-musl.tar.gz | tar -xzf - --to-stdout > ~/.cargo/bin/cross
-        chmod +x ~/.cargo/bin/cross
-    - name: Build proot-rs
-      shell: bash
-      run: |
-        USE_CROSS=true CARGO_BUILD_TARGET="${{ matrix.target }}" cargo make build
-    - name: Upload artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: proot-rs-${{ matrix.target }}
-        path: target/${{ matrix.target }}/debug/proot-rs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,3 @@ members = [
 
 [profile.release]
 strip = true
-
-[profile.dev.package.loader-shim]
-opt-level = 1
-
-[profile.release.package.loader-shim]
-opt-level = "s"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,13 @@
+cargo-features = ["strip"]
+
 [workspace]
 members = [
   "proot-rs",
   "loader-shim",
 ]
+
+[profile.release]
+strip = true
 
 [profile.dev.package.loader-shim]
 opt-level = 1

--- a/loader-shim/src/main.rs
+++ b/loader-shim/src/main.rs
@@ -17,7 +17,10 @@
 // system standard libraries.
 // See https://gcc.gnu.org/onlinedocs/gcc/Link-Options.html
 //
-// Since _start is defined in the system startup files, with this option
+// The `-nostdlib` flag is much like a combination of `-nostartfiles` and
+// `-nodefaultlibs`.
+//
+// Since `_start` is defined in the system startup files, with this option
 // we can use our own `_start` function to override the program entry point.
 #[link_args = "-nostdlib"]
 #[link_args = "-ffreestanding"]
@@ -27,6 +30,18 @@
 #[cfg_attr(target_arch = "arm", link_args = "-Wl,-Ttext=0x10000000")]
 #[cfg_attr(target_arch = "aarch64", link_args = "-Wl,-Ttext=0x2000000000")]
 extern "C" {}
+
+// The compiler may emit a call to the `memset()` function even if there is
+// no such call in our code. However, since we use `-nostdlib` or
+// `-nodefaultlibs`, this means we will not link to libc, which provides the
+// implementation of `memset()`.
+//
+// In this case, we will get an `undefined reference to \`memset'` error.
+// Fortunately, the crate `rlibc` provides an unoptimized implementation of
+// `memset()`.
+//
+// See `-nodefaultlibs` at https://gcc.gnu.org/onlinedocs/gcc/Link-Options.html
+extern crate rlibc;
 
 mod script;
 


### PR DESCRIPTION
This PR adds two capabilities to our workflow:
- For each push, pull_request, check if the code can be cross-compiled successfully.
- If the push action pushes a tag, it also automatically appends the pre-built proot-rs executable files to the release page.

The released executable is built with the `--release` flag, which means that it is optimized and stripped.