### PR TITLE
Fix --version does not show version number

### DIFF
--- a/proot-rs/src/cli.rs
+++ b/proot-rs/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::{App, Arg};
+use clap::{crate_version, App, Arg};
 
 use crate::errors::*;
 use crate::filesystem::validation::{binding_validator, path_validator};
@@ -9,6 +9,8 @@ pub const DEFAULT_CWD: &'static str = "/";
 
 pub fn get_args_parser() -> App<'static, 'static> {
     App::new("proot-rs")
+        .about("chroot, mount --bind, and binfmt_misc without privilege/setup.")
+        .version(crate_version!())
         .arg(Arg::with_name("rootfs")
             .short("r")
             .long("rootfs")


### PR DESCRIPTION
This PR fixes https://github.com/proot-me/proot-rs/issues/58

```
$ cargo make run -- --help
proot-rs 0.1.0
chroot, mount --bind, and binfmt_misc without privilege/setup.

USAGE:
    proot-rs [OPTIONS] [--] [command]...

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -b, --bind <bind>...     Make the content of *host_path* accessible in the guest rootfs. Format:
                             host_path:guest_path
    -w, --cwd <cwd>          Set the initial working directory to *path*. [default: /]
    -r, --rootfs <rootfs>    Use *path* as the new guest root file-system. [default: /]

ARGS:
    <command>...    
```

```
$ cargo make run -- --version
proot-rs 0.1.0
```