### PR TITLE
Fix deadlock in unit test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,7 +75,7 @@ jobs:
     - name: Run unit tests
       shell: bash
       run: |
-        PROOT_TEST_ROOTFS="$(pwd)/rootfs" cargo test --package=proot-rs --verbose -- --nocapture
+        PROOT_TEST_ROOTFS="$(pwd)/rootfs" cargo test --package=proot-rs --verbose -- --test-threads=1 --nocapture
     - name: Setup bats-core
       uses: mig4/setup-bats@v1
       with:

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -65,7 +65,7 @@ script = '''
 if [ -z "${PROOT_TEST_ROOTFS}" ]; then
     export PROOT_TEST_ROOTFS="$(pwd)/rootfs"
 fi
-"$CARGO" test --package=proot-rs ${CARGO_EXTRA_FLAGS}
+"$CARGO" test --package=proot-rs ${CARGO_EXTRA_FLAGS} ${@} -- --test-threads=1 --nocapture
 '''
 
 [tasks.integration-test]

--- a/README.md
+++ b/README.md
@@ -172,15 +172,13 @@ bash scripts/mkrootfs.sh
 Start running unit tests:
 
 ```shell
-cargo make unit-test
+export PROOT_TEST_ROOTFS="`realpath ./rootfs/`"
+cargo test --package=proot-rs -- --test-threads=1
 ```
-> Note: Add the option `--profile=production` if you want to test a release build of proot-rs
 
-By default, By default, `./rootfs/` will be used as the root filesystem for testing purposes. But you can set the environment variable `PROOT_TEST_ROOTFS` to change this behavior.
-
-```shell
-export PROOT_TEST_ROOTFS="<absolute-path-to-a-rootfs>"
-```
+> Note:
+> - Since our testing will spawn multiple processes, we need `--test-threads=1` to avoid deadlock caused by `fork()`. The option `--nocapture` may also be needed to show the original panic reason printed out by the child process.
+> - Add the option `--profile=production` if you want to test a release build of proot-rs
 
 ### Integration testing
 

--- a/proot-rs/src/utils.rs
+++ b/proot-rs/src/utils.rs
@@ -58,7 +58,12 @@ pub mod tests {
                 }
             }
             Ok(ForkResult::Parent { child }) => {
-                assert_eq!(wait::waitpid(child, None), Ok(Exited(child, 0)))
+                assert_eq!(
+                    wait::waitpid(child, None),
+                    Ok(Exited(child, 0)),
+                    "A panic has occurred in the child process. If this is not expected behavior, \
+                    you may want to use --nocapture for the detailed panic messages."
+                )
             }
             Err(_) => panic!("Error: fork"),
         }


### PR DESCRIPTION
This commit fix a deadlock in unit test. The root cause of deadlocks is the use of `fork()` in a multi-threaded test environment.  

By setting `--test-threads=1` the deadlock can be avoided .